### PR TITLE
0.17.0: visual layout picker, in-place switching, insert command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.17.0
+
+You never need to memorize a layout letter again.
+
+### Added
+
+- **Visual layout picker**: an empty `image-layout` block now shows every
+  layout — grids a–i, single, masonry 2–6, and both carousel variants — as
+  small visual schematics instead of two text cards. Layouts that fit the
+  number of images already in the block are highlighted, and the picker
+  follows your theme.
+- **Change layout in place**: rendered layouts show a small button on hover
+  (faintly visible on touch devices) that reopens the picker. Modern blocks
+  rewrite their `layout` option; legacy blocks rename the fence
+  (`image-layout-a` → `image-layout-masonry-3`), so your documents keep
+  their format.
+- **Insert image layout command**: pick a layout from a modal and insert the
+  block at the cursor — or select image lines first and the command wraps
+  them. Works in source mode and on mobile.
+- The modern `image-layout` block now renders masonry too:
+  `layout: masonry-2` … `layout: masonry-6`.
+
+### Fixed
+
+- Choosing a layout when the block position can't be resolved (embeds,
+  exports) now shows a notice instead of silently doing nothing.
+
 ## 0.16.0
 
 The plugin was quietly broken in several long-standing ways — most notably it

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ When I find time I'm hoping to add the following:
 - Permanent overlays [DONE]
 - Overlays from markdown links [DONE]
 - General gallery to support scrolling through photos [DONE]
-- Captions from wikilinks, overlay never/hover/always, folder galleries, alignment and fit options [DONE - NEW!]
+- Captions from wikilinks, overlay never/hover/always, folder galleries, alignment and fit options [DONE]
+- Visually pick layouts — every layout, in the block and from the command palette [DONE - NEW!]
 - Drag and drop support
-- Visually pick empty layouts [PARTIAL]
 - User-definable custom layouts (#15)
 
 ## Documentation

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,5 +1,16 @@
 # Block Options Reference
 
+An empty `image-layout` block shows a visual picker with every layout —
+grids, masonry, and carousel — as small schematics; layouts matching the
+number of images already in the block are highlighted. Rendered layouts show
+a change-layout button on hover to reopen the picker. There is also an
+**Insert image layout** command in the command palette that wraps the
+current selection.
+
+The modern `image-layout` block accepts `layout: a` … `layout: i`,
+`layout: single`, `layout: masonry-2` … `layout: masonry-6`, or
+`layout: carousel`.
+
 Every layout block accepts options as YAML front matter inside the codeblock:
 
 ````

--- a/src/components/LayoutPicker.svelte
+++ b/src/components/LayoutPicker.svelte
@@ -51,8 +51,12 @@
         type="button"
         class="tile"
         class:fits={imageCount > 0 && layoutImages[layout] === imageCount}
+        class:over={imageCount > 0 && layoutImages[layout] < imageCount}
         class:current={currentLayout === layout}
         aria-label={`Grid layout ${layout} (${layoutImages[layout]} images)`}
+        title={imageCount > layoutImages[layout]
+          ? `Shows the first ${layoutImages[layout]} of your ${imageCount} images`
+          : undefined}
         on:click={() => select(layout)}
       >
         <LayoutSchematic grid={layout} />
@@ -95,6 +99,7 @@
       <button
         type="button"
         class="tile"
+        class:current={currentLayout === "carousel-thumbnails"}
         aria-label="Carousel with thumbnails"
         on:click={() => select("carousel", { showThumbnails: true })}
       >
@@ -191,6 +196,16 @@
   .tile.current {
     border-style: dashed;
     border-color: var(--text-muted);
+  }
+
+  /* Grids that can't show every image in the block are dimmed; the title
+     attribute explains what would be hidden. */
+  .tile.over {
+    opacity: 0.55;
+  }
+
+  .tile.over:hover {
+    opacity: 1;
   }
 
   .tile-label {

--- a/src/components/LayoutPicker.svelte
+++ b/src/components/LayoutPicker.svelte
@@ -1,117 +1,202 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import type { LayoutType } from "../interfaces";
+  import {
+    type LayoutType,
+    layoutImages,
+    layoutTemplates,
+  } from "../interfaces";
+  import LayoutSchematic from "./LayoutSchematic.svelte";
+
+  // How many images the block already contains; grids needing exactly that
+  // many are highlighted.
+  export let imageCount: number = 0;
+  // Legacy blocks can only be renamed to other legacy fences, which have no
+  // carousel form.
+  export let allowCarousel: boolean = true;
+  // Set when switching an existing block, to mark the current layout.
+  export let currentLayout: string | undefined = undefined;
+  export let showCancel: boolean = false;
+
   const dispatch = createEventDispatcher();
 
-  async function selectLayout(
-    event: KeyboardEvent | MouseEvent,
-    layout: LayoutType | "carousel",
-    params?: any
-  ) {
-    event.preventDefault();
-    await dispatch("layout-selected", {
-      type: layout,
-      params,
-    });
+  const gridLayouts = Object.keys(layoutTemplates) as LayoutType[];
+  const masonryColumns = [2, 3, 4, 5, 6];
+
+  function select(type: string, params?: { showThumbnails?: boolean }) {
+    dispatch("layout-selected", { type, params });
   }
 </script>
 
-<div class="p-4 bg-gray-50">
-  <div class="text-base font-semibold leading-6 text-gray-900">
-    Select an image layout
-  </div>
-  <div class="text-xs font-normal leading-6 text-gray-900">
-    More layouts coming soon
+<div class="image-layouts-picker cursor-default">
+  <div class="picker-header">
+    <span class="picker-title">Pick an image layout</span>
+    {#if imageCount > 0}
+      <span class="picker-count"
+        >{imageCount} image{imageCount === 1 ? "" : "s"} in this block</span
+      >
+    {/if}
+    {#if showCancel}
+      <button
+        type="button"
+        class="picker-cancel"
+        on:click={() => dispatch("cancel")}>Cancel</button
+      >
+    {/if}
   </div>
 
-  <div class="mt-4 grid grid-cols-1 gap-y-6 sm:grid-cols-3 sm:gap-x-4">
-    <label
-      class="relative flex cursor-pointer rounded-lg border bg-white p-4 shadow-sm focus:outline-none"
-      on:click={(event) => selectLayout(event, "carousel")}
-      on:keydown={(event) => selectLayout(event, "carousel")}
-    >
-      <input
-        type="radio"
-        name="project-type"
-        value="Carousel"
-        class="sr-only"
-        aria-labelledby="project-type-0-label"
-        aria-describedby="project-type-0-description-0 project-type-0-description-1"
-      />
-      <span class="flex flex-1">
-        <span class="flex flex-col">
-          <span
-            id="project-type-0-label"
-            class="block text-sm font-medium text-gray-900">Carousel</span
-          >
-          <span
-            id="project-type-0-description-0"
-            class="mt-1 flex items-center text-sm text-gray-500"
-            >Without thumbnails. Simple pills and slider</span
-          >
-        </span>
-      </span>
-      <svg
-        class="h-5 w-5 text-indigo-600"
-        viewBox="0 0 20 20"
-        fill="currentColor"
-        aria-hidden="true"
+  <div class="picker-section">Grids</div>
+  <div class="picker-tiles">
+    {#each gridLayouts as layout}
+      <button
+        type="button"
+        class="tile"
+        class:fits={imageCount > 0 && layoutImages[layout] === imageCount}
+        class:current={currentLayout === layout}
+        aria-label={`Grid layout ${layout} (${layoutImages[layout]} images)`}
+        on:click={() => select(layout)}
       >
-        <path
-          fill-rule="evenodd"
-          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
-          clip-rule="evenodd"
-        />
-      </svg>
-      <span
-        class="pointer-events-none absolute -inset-px rounded-lg border-2"
-        aria-hidden="true"
-      ></span>
-    </label>
-    <label
-      class="relative flex cursor-pointer rounded-lg border bg-white p-4 shadow-sm focus:outline-none"
-      on:click={(event) =>
-        selectLayout(event, "carousel", { showThumbnails: true })}
-      on:keydown={(event) =>
-        selectLayout(event, "carousel", { showThumbnails: true })}
-    >
-      <input
-        type="radio"
-        name="project-type"
-        value="carousel-thumbnails"
-        class="sr-only"
-        aria-labelledby="project-type-1-label"
-        aria-describedby="project-type-1-description-0 project-type-1-description-1"
-      />
-      <span class="flex flex-1">
-        <span class="flex flex-col">
-          <span
-            id="project-type-1-label"
-            class="block text-sm font-medium text-gray-900">Carousel</span
-          >
-          <span
-            id="project-type-1-description-0"
-            class="mt-1 flex items-center text-sm text-gray-500"
-            >With thumbnails</span
-          >
-        </span>
-      </span>
-      <svg
-        class="h-5 w-5 text-indigo-600"
-        viewBox="0 0 20 20"
-        fill="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          fill-rule="evenodd"
-          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
-          clip-rule="evenodd"
-        />
-      </svg>
-      <span
-        class="pointer-events-none absolute -inset-px rounded-lg border-2"
-        aria-hidden="true"
-      ></span>
-    </label>
+        <LayoutSchematic grid={layout} />
+        <span class="tile-label"
+          >{layout} · {layoutImages[layout]}</span
+        >
+      </button>
+    {/each}
   </div>
+
+  <div class="picker-section">Masonry</div>
+  <div class="picker-tiles">
+    {#each masonryColumns as columns}
+      <button
+        type="button"
+        class="tile"
+        class:current={currentLayout === `masonry-${columns}`}
+        aria-label={`Masonry with ${columns} columns`}
+        on:click={() => select(`masonry-${columns}`)}
+      >
+        <LayoutSchematic masonryColumns={columns} />
+        <span class="tile-label">{columns} col</span>
+      </button>
+    {/each}
+  </div>
+
+  {#if allowCarousel}
+    <div class="picker-section">Carousel</div>
+    <div class="picker-tiles">
+      <button
+        type="button"
+        class="tile"
+        class:current={currentLayout === "carousel"}
+        aria-label="Carousel with pill indicators"
+        on:click={() => select("carousel")}
+      >
+        <LayoutSchematic carousel="pills" />
+        <span class="tile-label">pills</span>
+      </button>
+      <button
+        type="button"
+        class="tile"
+        aria-label="Carousel with thumbnails"
+        on:click={() => select("carousel", { showThumbnails: true })}
+      >
+        <LayoutSchematic carousel="thumbnails" />
+        <span class="tile-label">thumbnails</span>
+      </button>
+    </div>
+  {/if}
 </div>
+
+<style>
+  .image-layouts-picker {
+    padding: 0.75rem;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 8px;
+    background-color: var(--background-secondary);
+    color: var(--text-normal);
+  }
+
+  .picker-header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .picker-title {
+    font-weight: 600;
+    font-size: 0.9rem;
+  }
+
+  .picker-count {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+
+  .picker-cancel {
+    margin-left: auto;
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background-color: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .picker-cancel:hover {
+    color: var(--text-normal);
+    background-color: var(--background-modifier-hover);
+  }
+
+  .picker-section {
+    margin-top: 0.75rem;
+    margin-bottom: 0.25rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+  }
+
+  .picker-tiles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .tile {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 76px;
+    padding: 6px 6px 4px;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 6px;
+    background-color: var(--background-primary);
+    cursor: pointer;
+    box-shadow: none;
+  }
+
+  .tile :global(.schematic) {
+    height: 48px;
+  }
+
+  .tile:hover {
+    border-color: var(--interactive-accent);
+    background-color: var(--background-modifier-hover);
+  }
+
+  .tile.fits {
+    border-color: var(--interactive-accent);
+    box-shadow: 0 0 0 1px var(--interactive-accent);
+  }
+
+  .tile.current {
+    border-style: dashed;
+    border-color: var(--text-muted);
+  }
+
+  .tile-label {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    text-align: center;
+    line-height: 1.2;
+  }
+</style>

--- a/src/components/LayoutSchematic.svelte
+++ b/src/components/LayoutSchematic.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import {
+    type LayoutType,
+    layoutImages,
+    layoutTemplates,
+  } from "../interfaces";
+
+  // One of: a grid layout letter/single, a masonry column count, or a
+  // carousel variant.
+  export let grid: LayoutType | undefined = undefined;
+  export let masonryColumns: number | undefined = undefined;
+  export let carousel: "pills" | "thumbnails" | undefined = undefined;
+
+  // Alternating block heights give the masonry schematic its stagger.
+  const masonryHeights = [
+    ["55%", "40%"],
+    ["35%", "60%"],
+    ["50%", "45%"],
+  ];
+</script>
+
+<div class="schematic" aria-hidden="true">
+  {#if grid}
+    <div
+      class="schematic-grid"
+      style:grid-template-columns={layoutTemplates[grid].columns}
+      style:grid-template-areas={layoutTemplates[grid].areas}
+    >
+      {#each Array(layoutImages[grid]) as _, index}
+        <div class="cell" style:grid-area={`image-${index}`}></div>
+      {/each}
+    </div>
+  {:else if masonryColumns}
+    <div class="schematic-masonry">
+      {#each Array(masonryColumns) as _, col}
+        <div class="masonry-column">
+          {#each masonryHeights[col % masonryHeights.length] as height}
+            <div class="cell" style:height></div>
+          {/each}
+        </div>
+      {/each}
+    </div>
+  {:else if carousel}
+    <div class="schematic-carousel">
+      <div class="cell stage"></div>
+      <div class="strip">
+        {#if carousel === "pills"}
+          {#each Array(3) as _}
+            <div class="pill"></div>
+          {/each}
+        {:else}
+          {#each Array(3) as _}
+            <div class="cell thumb"></div>
+          {/each}
+        {/if}
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .schematic {
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  .cell {
+    background-color: var(--background-modifier-border);
+    border-radius: 2px;
+  }
+
+  .schematic-grid {
+    display: grid;
+    gap: 3px;
+    width: 100%;
+    height: 100%;
+    grid-auto-rows: 1fr;
+  }
+
+  .schematic-masonry {
+    display: flex;
+    gap: 3px;
+    width: 100%;
+    height: 100%;
+  }
+
+  .masonry-column {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .schematic-carousel {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    width: 100%;
+    height: 100%;
+  }
+
+  .stage {
+    flex: 1;
+  }
+
+  .strip {
+    display: flex;
+    gap: 3px;
+    height: 22%;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .pill {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background-color: var(--background-modifier-border);
+  }
+
+  .thumb {
+    flex: 0 0 26%;
+    height: 100%;
+  }
+</style>

--- a/src/components/SwitchableLayout.svelte
+++ b/src/components/SwitchableLayout.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { createEventDispatcher, type ComponentType } from "svelte";
+  import LayoutPicker from "./LayoutPicker.svelte";
+
+  // The layout component to render (grid, masonry, or carousel) and its props.
+  export let component: ComponentType;
+  export let componentProps: Record<string, unknown> = {};
+  // Whether the surrounding context can write the change back to the note.
+  export let switchable: boolean = false;
+  export let imageCount: number = 0;
+  export let allowCarousel: boolean = true;
+  export let currentLayout: string | undefined = undefined;
+
+  const dispatch = createEventDispatcher();
+  let picking = false;
+
+  function apply(event: CustomEvent) {
+    picking = false;
+    dispatch("apply-layout", event.detail);
+  }
+</script>
+
+{#if picking}
+  <LayoutPicker
+    {imageCount}
+    {allowCarousel}
+    {currentLayout}
+    showCancel={true}
+    on:layout-selected={apply}
+    on:cancel={() => (picking = false)}
+  />
+{:else}
+  <div class="switchable-layout">
+    <svelte:component this={component} {...componentProps} />
+    {#if switchable}
+      <button
+        type="button"
+        class="switch-button"
+        aria-label="Change layout"
+        title="Change layout"
+        on:click={() => (picking = true)}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="3" y="3" width="7" height="7" rx="1" />
+          <rect x="14" y="3" width="7" height="7" rx="1" />
+          <rect x="3" y="14" width="7" height="7" rx="1" />
+          <rect x="14" y="14" width="7" height="7" rx="1" />
+        </svg>
+      </button>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .switchable-layout {
+    position: relative;
+  }
+
+  .switch-button {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border-radius: 6px;
+    border: 1px solid var(--background-modifier-border);
+    background-color: var(--background-secondary);
+    color: var(--text-muted);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 120ms ease-in-out;
+  }
+
+  .switchable-layout:hover .switch-button,
+  .switch-button:focus-visible {
+    opacity: 1;
+  }
+
+  /* No hover on touch devices — keep the button faintly visible instead. */
+  @media (hover: none) {
+    .switch-button {
+      opacity: 0.6;
+    }
+  }
+
+  .switch-button:hover {
+    color: var(--text-normal);
+    border-color: var(--interactive-accent);
+  }
+</style>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,6 +24,41 @@ export const layoutImages: Record<LayoutType, number> = {
   single: 1,
 };
 
+// One entry per grid layout, mirroring the CSS in LegacyImageLayout.svelte.
+// Used by the layout picker to draw miniature schematics of each grid.
+export type GridTemplate = {
+  columns: string;
+  areas: string;
+};
+
+export const layoutTemplates: Record<LayoutType, GridTemplate> = {
+  a: { columns: "1fr 1fr", areas: '"image-0 image-1"' },
+  b: { columns: "2fr 1fr", areas: '"image-0 image-1"' },
+  c: { columns: "1fr 2fr", areas: '"image-1 image-0"' },
+  d: { columns: "2fr 1fr", areas: '"image-0 image-1" "image-0 image-2"' },
+  e: { columns: "1fr 2fr", areas: '"image-1 image-0" "image-2 image-0"' },
+  f: {
+    columns: "3fr 1fr",
+    areas: '"image-0 image-1" "image-0 image-2" "image-0 image-3"',
+  },
+  g: {
+    columns: "1fr 3fr",
+    areas: '"image-1 image-0" "image-2 image-0" "image-3 image-0"',
+  },
+  h: { columns: "1fr 1fr 1fr", areas: '"image-0 image-1 image-2"' },
+  i: {
+    columns: "1fr 1fr 1fr 1fr",
+    areas: '"image-0 image-1 image-2 image-3"',
+  },
+  single: { columns: "1fr", areas: '"image-0"' },
+};
+
+// What the layout picker emits: a grid letter, single, masonry-N, or carousel.
+export type PickerChoice = {
+  type: string;
+  params?: { showThumbnails?: boolean };
+};
+
 export type FitMode = "cover" | "contain" | "natural";
 export type AlignMode = "left" | "center" | "right" | "full";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,9 @@ import { addLegacyImageLayoutMarkdownProcessors } from "./processors/legacy-imag
 import { addLegacyMasonryMarkdownProcessors } from "./processors/legacy-masory-layouts";
 import { settings as s } from "./stores";
 import type { ImageLayoutsSettings } from "./types";
+import { buildLayoutBlock } from "./utils/blocks";
+import { getImages } from "./utils/images";
+import { ImageLayoutPickerModal } from "./views/picker-modal";
 import { ImageLayoutsSettingsTab } from "./views/settings";
 import "virtual:uno.css";
 
@@ -37,6 +40,19 @@ export default class ImageLayoutsPlugin extends Plugin {
     await this.loadSettings();
 
     this.addSettingTab(new ImageLayoutsSettingsTab(this.app, this));
+
+    this.addCommand({
+      id: "insert-image-layout",
+      name: "Insert image layout",
+      icon: "layout-grid",
+      editorCallback: (editor) => {
+        const selection = editor.getSelection();
+        const imageCount = getImages(selection).length;
+        new ImageLayoutPickerModal(this.app, imageCount, (choice) => {
+          editor.replaceSelection(buildLayoutBlock(choice, selection));
+        }).open();
+      },
+    });
 
     addImageLayoutMarkdownProcessor(this);
     addLegacyImageLayoutMarkdownProcessors(this);

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,11 @@ export default class ImageLayoutsPlugin extends Plugin {
         const selection = editor.getSelection();
         const imageCount = getImages(selection).length;
         new ImageLayoutPickerModal(this.app, imageCount, (choice) => {
-          editor.replaceSelection(buildLayoutBlock(choice, selection));
+          // A fence that starts mid-line isn't parsed as a codeblock.
+          const from = editor.getCursor("from");
+          const beforeCursor = editor.getLine(from.line).slice(0, from.ch);
+          const prefix = beforeCursor.trim() === "" ? "" : "\n";
+          editor.replaceSelection(prefix + buildLayoutBlock(choice, selection));
         }).open();
       },
     });

--- a/src/processors/image-layout.ts
+++ b/src/processors/image-layout.ts
@@ -14,8 +14,11 @@ import {
 } from "../interfaces";
 import type ImageLayoutsPlugin from "../main";
 import { collectBlockImages } from "../utils/block-images";
-import { parseMasonryLayoutName } from "../utils/blocks";
-import { writeBlockData } from "../utils/editor-writeback";
+import {
+  parseMasonryLayoutName,
+  updateLayoutInBlockSource,
+} from "../utils/blocks";
+import { writeBlockSource } from "../utils/editor-writeback";
 import { parseFrontMatterBlock } from "../utils/front-matter";
 import { normalizeAlign, normalizeDescriptions } from "../utils/options";
 import { resolveOverlayMode } from "../utils/overlay";
@@ -47,24 +50,10 @@ export function renderImageLayoutComponent(
   const layout = typeof m.data?.layout === "string" ? m.data.layout : undefined;
 
   const applyChoice = (choice: PickerChoice) => {
-    const newData: ImageLayoutBlockOptions = { ...(m.data ?? {}) };
-    newData.layout = choice.type;
-    if (choice.type === "carousel") {
-      if (choice.params?.showThumbnails) {
-        newData.carouselShowThumbnails = true;
-      } else {
-        newData.carouselShowThumbnails = undefined;
-      }
-    }
-    if (
-      !writeBlockData(
-        plugin,
-        ctx,
-        parent,
-        m.body,
-        newData as Record<string, unknown>,
-      )
-    ) {
+    // Edits only the layout lines of the raw source, preserving the user's
+    // comments and formatting.
+    const newSource = updateLayoutInBlockSource(source, choice);
+    if (!writeBlockSource(plugin, ctx, parent, newSource)) {
       new Notice("Image Layouts: the layout can't be changed in this view.");
     }
     // On success the editor change re-runs this processor with the new
@@ -120,7 +109,7 @@ export function renderImageLayoutComponent(
         background: m.data.carouselBackground,
         height: m.data.carouselHeight,
       },
-      "carousel",
+      m.data.carouselShowThumbnails ? "carousel-thumbnails" : "carousel",
     );
     return;
   }

--- a/src/processors/image-layout.ts
+++ b/src/processors/image-layout.ts
@@ -1,19 +1,22 @@
 import CarouselComponent from "../components/Carousel.svelte";
 import LayoutPickerComponent from "../components/LayoutPicker.svelte";
 import LegacyLayoutComponent from "../components/LegacyImageLayout.svelte";
+import LegacyMasonryLayout from "../components/LegacyMasonryLayout.svelte";
+import SwitchableLayout from "../components/SwitchableLayout.svelte";
 
-import { type MarkdownPostProcessorContext, MarkdownView } from "obsidian";
+import { type MarkdownPostProcessorContext, Notice } from "obsidian";
+import type { ComponentType } from "svelte";
 import {
   type ImageLayoutBlockOptions,
   type LayoutType,
+  type PickerChoice,
   layoutImages,
 } from "../interfaces";
 import type ImageLayoutsPlugin from "../main";
 import { collectBlockImages } from "../utils/block-images";
-import {
-  parseFrontMatterBlock,
-  stringifyFrontMatterBlock,
-} from "../utils/front-matter";
+import { parseMasonryLayoutName } from "../utils/blocks";
+import { writeBlockData } from "../utils/editor-writeback";
+import { parseFrontMatterBlock } from "../utils/front-matter";
 import { normalizeAlign, normalizeDescriptions } from "../utils/options";
 import { resolveOverlayMode } from "../utils/overlay";
 import { resolvePlaceholderImage } from "../utils/placeholder";
@@ -42,55 +45,71 @@ export function renderImageLayoutComponent(
 
   // A non-string layout value (e.g. `layout: 1`) is treated as unset.
   const layout = typeof m.data?.layout === "string" ? m.data.layout : undefined;
+
+  const applyChoice = (choice: PickerChoice) => {
+    const newData: ImageLayoutBlockOptions = { ...(m.data ?? {}) };
+    newData.layout = choice.type;
+    if (choice.type === "carousel") {
+      if (choice.params?.showThumbnails) {
+        newData.carouselShowThumbnails = true;
+      } else {
+        newData.carouselShowThumbnails = undefined;
+      }
+    }
+    if (
+      !writeBlockData(
+        plugin,
+        ctx,
+        parent,
+        m.body,
+        newData as Record<string, unknown>,
+      )
+    ) {
+      new Notice("Image Layouts: the layout can't be changed in this view.");
+    }
+    // On success the editor change re-runs this processor with the new
+    // source, unmounting the picker and rendering the chosen layout.
+  };
+
   if (!m.data || !layout) {
     const picker = new LayoutPickerComponent({
       target: parent,
-      props: {},
+      props: { imageCount: readyImages.length },
     });
     ctx.addChild(new SvelteRenderChild(parent, picker));
-    picker.$on(
-      "layout-selected",
-      (
-        event: CustomEvent<{
-          type: LayoutType | "carousel";
-          params?: { showThumbnails?: boolean };
-        }>,
-      ) => {
-        const newData = m.data ?? {};
-        newData.layout = event.detail.type;
-        if (event.detail.params?.showThumbnails) {
-          newData.carouselShowThumbnails = true;
-        }
-        // view contains the editor to change the markdown
-        const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
-        // the context contains the begin and end of the block in the markdown file
-        const info = ctx.getSectionInfo(parent);
-
-        if (info) {
-          view?.editor.setSelection(
-            {
-              line: info.lineEnd,
-              ch: 0,
-            },
-            {
-              line: info.lineStart + 1,
-              ch: 0,
-            },
-          );
-          view?.editor.replaceSelection(
-            stringifyFrontMatterBlock(m.body, newData),
-          );
-        }
-        // The editor change makes Obsidian re-run this processor with the
-        // updated source, unmounting the picker and rendering the layout.
-      },
-    );
+    picker.$on("layout-selected", (event: CustomEvent<PickerChoice>) => {
+      applyChoice(event.detail);
+    });
     return;
   }
-  if (layout === "carousel") {
-    const carousel = new CarouselComponent({
+
+  const switchable = ctx.getSectionInfo(parent) !== null;
+  const mountSwitchable = (
+    component: ComponentType,
+    componentProps: Record<string, unknown>,
+    currentLayout: string,
+  ) => {
+    const wrapper = new SwitchableLayout({
       target: parent,
       props: {
+        component,
+        componentProps,
+        switchable,
+        imageCount: readyImages.length,
+        allowCarousel: true,
+        currentLayout,
+      },
+    });
+    wrapper.$on("apply-layout", (event: CustomEvent<PickerChoice>) => {
+      applyChoice(event.detail);
+    });
+    ctx.addChild(new SvelteRenderChild(parent, wrapper));
+  };
+
+  if (layout === "carousel") {
+    mountSwitchable(
+      CarouselComponent,
+      {
         images:
           readyImages.length > 0
             ? readyImages
@@ -101,10 +120,27 @@ export function renderImageLayoutComponent(
         background: m.data.carouselBackground,
         height: m.data.carouselHeight,
       },
-    });
-    ctx.addChild(new SvelteRenderChild(parent, carousel));
+      "carousel",
+    );
     return;
   }
+
+  const masonryColumns = parseMasonryLayoutName(layout);
+  if (masonryColumns !== null) {
+    mountSwitchable(
+      LegacyMasonryLayout,
+      {
+        caption: m.data.caption ?? "",
+        descriptions,
+        columns: masonryColumns,
+        images: readyImages,
+        overlayMode: resolveOverlayMode(m.data, plugin.settings),
+      },
+      layout,
+    );
+    return;
+  }
+
   // Accept both `layout: legacy-layout-a` and plain `layout: a`. Slicing the
   // prefix (rather than taking the last character) keeps `single` working.
   const layoutName = layout.startsWith(LEGACY_LAYOUT_PREFIX)
@@ -112,9 +148,9 @@ export function renderImageLayoutComponent(
     : layout;
   if (layoutImages[layoutName as LayoutType]) {
     const layoutType = layoutName as LayoutType;
-    const component = new LegacyLayoutComponent({
-      target: parent,
-      props: {
+    mountSwitchable(
+      LegacyLayoutComponent,
+      {
         caption: m.data.caption ?? "",
         descriptions,
         layout: layoutType,
@@ -126,7 +162,7 @@ export function renderImageLayoutComponent(
         width: m.data.width,
         placeholderUrl: resolvePlaceholderImage(plugin),
       },
-    });
-    ctx.addChild(new SvelteRenderChild(parent, component));
+      layoutType,
+    );
   }
 }

--- a/src/processors/legacy-image-layouts.ts
+++ b/src/processors/legacy-image-layouts.ts
@@ -52,6 +52,7 @@ export function addLegacyImageLayoutMarkdownProcessors(
           plugin,
           "single",
           ALIGN_SHORTHANDS[shorthand],
+          shorthand,
         );
       },
     );
@@ -78,6 +79,10 @@ export function renderLegacyLayoutComponent(
   plugin: ImageLayoutsPlugin,
   layout: LayoutType,
   defaultAlign: AlignMode = "full",
+  // The token in the fence name — differs from `layout` for the align
+  // shorthands (image-layout-left renders `single` but its token is `left`),
+  // and the picker must not mark `single` as current for those blocks.
+  fenceLayout: string = layout,
 ) {
   const m = parseFrontMatterBlock<LayoutBlockOptions>(source);
   const readyImages = collectBlockImages(m.data, m.body, ctx, plugin);
@@ -101,7 +106,7 @@ export function renderLegacyLayoutComponent(
       switchable: ctx.getSectionInfo(parent) !== null,
       imageCount: readyImages.length,
       allowCarousel: false,
-      currentLayout: layout,
+      currentLayout: fenceLayout,
     },
   });
   wrapper.$on("apply-layout", (event: CustomEvent<PickerChoice>) => {

--- a/src/processors/legacy-image-layouts.ts
+++ b/src/processors/legacy-image-layouts.ts
@@ -1,13 +1,16 @@
-import type { MarkdownPostProcessorContext } from "obsidian";
+import { type MarkdownPostProcessorContext, Notice } from "obsidian";
 import LayoutComponent from "../components/LegacyImageLayout.svelte";
+import SwitchableLayout from "../components/SwitchableLayout.svelte";
 import {
   type AlignMode,
   type LayoutBlockOptions,
   type LayoutType,
+  type PickerChoice,
   layoutImages,
 } from "../interfaces";
 import type ImageLayoutsPlugin from "../main";
 import { collectBlockImages } from "../utils/block-images";
+import { renameFenceLayout } from "../utils/editor-writeback";
 import { parseFrontMatterBlock } from "../utils/front-matter";
 import { normalizeAlign, normalizeDescriptions } from "../utils/options";
 import { resolveOverlayMode } from "../utils/overlay";
@@ -55,6 +58,19 @@ export function addLegacyImageLayoutMarkdownProcessors(
   }
 }
 
+// Legacy blocks encode the layout in the fence name, so applying a picker
+// choice means renaming the fence token; the fences have no carousel form.
+export function applyLegacyPickerChoice(
+  plugin: ImageLayoutsPlugin,
+  ctx: MarkdownPostProcessorContext,
+  parent: HTMLElement,
+  choice: PickerChoice,
+) {
+  if (!renameFenceLayout(plugin, ctx, parent, choice.type)) {
+    new Notice("Image Layouts: the layout can't be changed in this view.");
+  }
+}
+
 export function renderLegacyLayoutComponent(
   source: string,
   parent: HTMLElement,
@@ -66,20 +82,30 @@ export function renderLegacyLayoutComponent(
   const m = parseFrontMatterBlock<LayoutBlockOptions>(source);
   const readyImages = collectBlockImages(m.data, m.body, ctx, plugin);
 
-  const component = new LayoutComponent({
+  const wrapper = new SwitchableLayout({
     target: parent,
     props: {
-      caption: m.data?.caption ?? "",
-      descriptions: normalizeDescriptions(m.data?.descriptions),
-      layout: layout,
-      requiredImages: layoutImages[layout],
-      images: readyImages,
-      overlayMode: resolveOverlayMode(m.data, plugin.settings),
-      fit: m.data?.fit,
-      align: normalizeAlign(m.data?.align, defaultAlign),
-      width: m.data?.width,
-      placeholderUrl: resolvePlaceholderImage(plugin),
+      component: LayoutComponent,
+      componentProps: {
+        caption: m.data?.caption ?? "",
+        descriptions: normalizeDescriptions(m.data?.descriptions),
+        layout: layout,
+        requiredImages: layoutImages[layout],
+        images: readyImages,
+        overlayMode: resolveOverlayMode(m.data, plugin.settings),
+        fit: m.data?.fit,
+        align: normalizeAlign(m.data?.align, defaultAlign),
+        width: m.data?.width,
+        placeholderUrl: resolvePlaceholderImage(plugin),
+      },
+      switchable: ctx.getSectionInfo(parent) !== null,
+      imageCount: readyImages.length,
+      allowCarousel: false,
+      currentLayout: layout,
     },
   });
-  ctx.addChild(new SvelteRenderChild(parent, component));
+  wrapper.$on("apply-layout", (event: CustomEvent<PickerChoice>) => {
+    applyLegacyPickerChoice(plugin, ctx, parent, event.detail);
+  });
+  ctx.addChild(new SvelteRenderChild(parent, wrapper));
 }

--- a/src/processors/legacy-masory-layouts.ts
+++ b/src/processors/legacy-masory-layouts.ts
@@ -1,12 +1,14 @@
 import type { MarkdownPostProcessorContext } from "obsidian";
 import LegacyMasonryLayout from "../components/LegacyMasonryLayout.svelte";
-import type { LayoutBlockOptions } from "../interfaces";
+import SwitchableLayout from "../components/SwitchableLayout.svelte";
+import type { LayoutBlockOptions, PickerChoice } from "../interfaces";
 import type ImageLayoutsPlugin from "../main";
 import { collectBlockImages } from "../utils/block-images";
 import { parseFrontMatterBlock } from "../utils/front-matter";
 import { normalizeDescriptions } from "../utils/options";
 import { resolveOverlayMode } from "../utils/overlay";
 import { SvelteRenderChild } from "../utils/svelte-render-child";
+import { applyLegacyPickerChoice } from "./legacy-image-layouts";
 
 export function addLegacyMasonryMarkdownProcessors(plugin: ImageLayoutsPlugin) {
   for (let columns = 2; columns <= 6; columns++) {
@@ -28,15 +30,25 @@ export function renderLegacyMasonryLayoutComponent(
 ) {
   const m = parseFrontMatterBlock<LayoutBlockOptions>(source);
   const readyImages = collectBlockImages(m.data, m.body, ctx, plugin);
-  const component = new LegacyMasonryLayout({
+  const wrapper = new SwitchableLayout({
     target: parent,
     props: {
-      caption: m.data?.caption ?? "",
-      descriptions: normalizeDescriptions(m.data?.descriptions),
-      columns: columns,
-      images: readyImages,
-      overlayMode: resolveOverlayMode(m.data, plugin.settings),
+      component: LegacyMasonryLayout,
+      componentProps: {
+        caption: m.data?.caption ?? "",
+        descriptions: normalizeDescriptions(m.data?.descriptions),
+        columns: columns,
+        images: readyImages,
+        overlayMode: resolveOverlayMode(m.data, plugin.settings),
+      },
+      switchable: ctx.getSectionInfo(parent) !== null,
+      imageCount: readyImages.length,
+      allowCarousel: false,
+      currentLayout: `masonry-${columns}`,
     },
   });
-  ctx.addChild(new SvelteRenderChild(parent, component));
+  wrapper.$on("apply-layout", (event: CustomEvent<PickerChoice>) => {
+    applyLegacyPickerChoice(plugin, ctx, parent, event.detail);
+  });
+  ctx.addChild(new SvelteRenderChild(parent, wrapper));
 }

--- a/src/utils/blocks.ts
+++ b/src/utils/blocks.ts
@@ -1,5 +1,4 @@
 import type { PickerChoice } from "../interfaces";
-import { stringifyFrontMatterBlock } from "./front-matter";
 
 // `layout: masonry-3` → 3; null for anything that isn't a masonry layout name.
 export const parseMasonryLayoutName = (layout: string): number | null => {
@@ -24,16 +23,70 @@ export const replaceFenceLayout = (
   return fenceLine.replace(/image-layout-[\w-]+/, `image-layout-${layout}`);
 };
 
+// Applies a picker choice to a block's raw source by editing only the
+// layout / carouselShowThumbnails lines. Everything else — comments, key
+// order, formatting — is preserved byte for byte, so switching layouts never
+// rewrites frontmatter the user authored by hand.
+export const updateLayoutInBlockSource = (
+  source: string,
+  choice: PickerChoice,
+): string => {
+  const layoutLine = `layout: ${choice.type}`;
+  const wantThumbnails =
+    choice.type === "carousel" && !!choice.params?.showThumbnails;
+  const thumbnailsLine = "carouselShowThumbnails: true";
+
+  const lines = source.split("\n");
+  if (lines[0]?.trim() === "---") {
+    const closing = lines.slice(1).findIndex((line) => line.trim() === "---");
+    if (closing >= 0) {
+      const end = closing + 1;
+      const inner = lines.slice(1, end);
+      const layoutIndex = inner.findIndex((line) =>
+        /^\s*layout\s*:/.test(line),
+      );
+      if (layoutIndex >= 0) {
+        inner[layoutIndex] = layoutLine;
+      } else {
+        inner.push(layoutLine);
+      }
+      const thumbnailsIndex = inner.findIndex((line) =>
+        /^\s*carouselShowThumbnails\s*:/.test(line),
+      );
+      if (wantThumbnails) {
+        if (thumbnailsIndex >= 0) {
+          inner[thumbnailsIndex] = thumbnailsLine;
+        } else {
+          inner.push(thumbnailsLine);
+        }
+      } else if (choice.type === "carousel" && thumbnailsIndex >= 0) {
+        inner.splice(thumbnailsIndex, 1);
+      }
+      const rest = lines.slice(end + 1).join("\n");
+      return `---\n${inner.join("\n")}\n---\n${rest}`;
+    }
+  }
+  const frontMatter = wantThumbnails
+    ? `---\n${layoutLine}\n${thumbnailsLine}\n---\n`
+    : `---\n${layoutLine}\n---\n`;
+  const body = source === "" || source.endsWith("\n") ? source : `${source}\n`;
+  return frontMatter + body;
+};
+
 // Builds a complete modern image-layout codeblock for the insert command.
+// The fence is longer than any backtick run in the content so selections
+// containing codeblocks can't terminate it early.
 export const buildLayoutBlock = (
   choice: PickerChoice,
   content = "",
 ): string => {
-  const data: Record<string, unknown> = { layout: choice.type };
-  if (choice.params?.showThumbnails) {
-    data.carouselShowThumbnails = true;
-  }
   const trimmed = content.trim();
   const body = trimmed === "" ? "" : `${trimmed}\n`;
-  return `\`\`\`image-layout\n${stringifyFrontMatterBlock(body, data)}\`\`\`\n`;
+  const inner = updateLayoutInBlockSource(body, choice);
+  const longestRun = Math.max(
+    0,
+    ...[...inner.matchAll(/`+/g)].map((match) => match[0].length),
+  );
+  const fence = "`".repeat(Math.max(3, longestRun + 1));
+  return `${fence}image-layout\n${inner}${fence}\n`;
 };

--- a/src/utils/blocks.ts
+++ b/src/utils/blocks.ts
@@ -1,0 +1,39 @@
+import type { PickerChoice } from "../interfaces";
+import { stringifyFrontMatterBlock } from "./front-matter";
+
+// `layout: masonry-3` → 3; null for anything that isn't a masonry layout name.
+export const parseMasonryLayoutName = (layout: string): number | null => {
+  const match = layout.match(/^masonry-(\d+)$/);
+  if (!match) {
+    return null;
+  }
+  const columns = Number(match[1]);
+  return columns >= 2 && columns <= 6 ? columns : null;
+};
+
+// Renames the layout token on a legacy codeblock fence line, e.g.
+// ```image-layout-a → ```image-layout-masonry-3. Returns null if the line
+// isn't a legacy image-layout fence.
+export const replaceFenceLayout = (
+  fenceLine: string,
+  layout: string,
+): string | null => {
+  if (!/^\s*(`{3,}|~{3,})\s*image-layout-[\w-]+\s*$/.test(fenceLine)) {
+    return null;
+  }
+  return fenceLine.replace(/image-layout-[\w-]+/, `image-layout-${layout}`);
+};
+
+// Builds a complete modern image-layout codeblock for the insert command.
+export const buildLayoutBlock = (
+  choice: PickerChoice,
+  content = "",
+): string => {
+  const data: Record<string, unknown> = { layout: choice.type };
+  if (choice.params?.showThumbnails) {
+    data.carouselShowThumbnails = true;
+  }
+  const trimmed = content.trim();
+  const body = trimmed === "" ? "" : `${trimmed}\n`;
+  return `\`\`\`image-layout\n${stringifyFrontMatterBlock(body, data)}\`\`\`\n`;
+};

--- a/src/utils/editor-writeback.ts
+++ b/src/utils/editor-writeback.ts
@@ -1,0 +1,53 @@
+import { type MarkdownPostProcessorContext, MarkdownView } from "obsidian";
+import type ImageLayoutsPlugin from "../main";
+import { replaceFenceLayout } from "./blocks";
+import { stringifyFrontMatterBlock } from "./front-matter";
+
+// Replaces the content between the fences of the codeblock rendered into
+// `parent` with new frontmatter + body. Returns false when the block's
+// position can't be resolved (embeds, exports).
+export function writeBlockData(
+  plugin: ImageLayoutsPlugin,
+  ctx: MarkdownPostProcessorContext,
+  parent: HTMLElement,
+  body: string,
+  data: Record<string, unknown>,
+): boolean {
+  const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+  const info = ctx.getSectionInfo(parent);
+  if (!view || !info) {
+    return false;
+  }
+  view.editor.setSelection(
+    { line: info.lineEnd, ch: 0 },
+    { line: info.lineStart + 1, ch: 0 },
+  );
+  view.editor.replaceSelection(stringifyFrontMatterBlock(body, data));
+  return true;
+}
+
+// Renames the layout token on a legacy block's opening fence line, e.g.
+// ```image-layout-a → ```image-layout-masonry-3.
+export function renameFenceLayout(
+  plugin: ImageLayoutsPlugin,
+  ctx: MarkdownPostProcessorContext,
+  parent: HTMLElement,
+  layout: string,
+): boolean {
+  const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+  const info = ctx.getSectionInfo(parent);
+  if (!view || !info) {
+    return false;
+  }
+  const fenceLine = view.editor.getLine(info.lineStart);
+  const renamed = replaceFenceLayout(fenceLine, layout);
+  if (renamed === null) {
+    return false;
+  }
+  view.editor.replaceRange(
+    renamed,
+    { line: info.lineStart, ch: 0 },
+    { line: info.lineStart, ch: fenceLine.length },
+  );
+  return true;
+}

--- a/src/utils/editor-writeback.ts
+++ b/src/utils/editor-writeback.ts
@@ -1,28 +1,52 @@
 import { type MarkdownPostProcessorContext, MarkdownView } from "obsidian";
 import type ImageLayoutsPlugin from "../main";
 import { replaceFenceLayout } from "./blocks";
-import { stringifyFrontMatterBlock } from "./front-matter";
+
+const OPENING_FENCE = /^\s*(?:`{3,}|~{3,})\s*image-layout/;
+const CLOSING_FENCE = /^\s*(?:`{3,}|~{3,})\s*$/;
+
+// The active editor, but only if it is showing the same file the block was
+// rendered from — hover popovers and embeds render blocks from other files
+// while a different note is active, and writing there would corrupt it.
+function editorForBlock(
+  plugin: ImageLayoutsPlugin,
+  ctx: MarkdownPostProcessorContext,
+) {
+  const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+  if (!view || view.file?.path !== ctx.sourcePath) {
+    return null;
+  }
+  return view.editor;
+}
 
 // Replaces the content between the fences of the codeblock rendered into
-// `parent` with new frontmatter + body. Returns false when the block's
-// position can't be resolved (embeds, exports).
-export function writeBlockData(
+// `parent` with new source text. Returns false when the block's position
+// can't be resolved or doesn't look like a fenced image-layout block (e.g.
+// an unclosed block at the end of a note, where lineEnd is content, not a
+// fence — writing there would mangle the note).
+export function writeBlockSource(
   plugin: ImageLayoutsPlugin,
   ctx: MarkdownPostProcessorContext,
   parent: HTMLElement,
-  body: string,
-  data: Record<string, unknown>,
+  source: string,
 ): boolean {
-  const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+  const editor = editorForBlock(plugin, ctx);
   const info = ctx.getSectionInfo(parent);
-  if (!view || !info) {
+  if (!editor || !info) {
     return false;
   }
-  view.editor.setSelection(
-    { line: info.lineEnd, ch: 0 },
+  if (
+    !OPENING_FENCE.test(editor.getLine(info.lineStart)) ||
+    !CLOSING_FENCE.test(editor.getLine(info.lineEnd))
+  ) {
+    return false;
+  }
+  const text = source === "" || source.endsWith("\n") ? source : `${source}\n`;
+  editor.replaceRange(
+    text,
     { line: info.lineStart + 1, ch: 0 },
+    { line: info.lineEnd, ch: 0 },
   );
-  view.editor.replaceSelection(stringifyFrontMatterBlock(body, data));
   return true;
 }
 
@@ -34,17 +58,17 @@ export function renameFenceLayout(
   parent: HTMLElement,
   layout: string,
 ): boolean {
-  const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+  const editor = editorForBlock(plugin, ctx);
   const info = ctx.getSectionInfo(parent);
-  if (!view || !info) {
+  if (!editor || !info) {
     return false;
   }
-  const fenceLine = view.editor.getLine(info.lineStart);
+  const fenceLine = editor.getLine(info.lineStart);
   const renamed = replaceFenceLayout(fenceLine, layout);
   if (renamed === null) {
     return false;
   }
-  view.editor.replaceRange(
+  editor.replaceRange(
     renamed,
     { line: info.lineStart, ch: 0 },
     { line: info.lineStart, ch: fenceLine.length },

--- a/src/views/picker-modal.ts
+++ b/src/views/picker-modal.ts
@@ -1,0 +1,43 @@
+import { App, Modal } from "obsidian";
+import LayoutPicker from "../components/LayoutPicker.svelte";
+import type { PickerChoice } from "../interfaces";
+
+export class ImageLayoutPickerModal extends Modal {
+  private component: LayoutPicker | null = null;
+  private imageCount: number;
+  private onChoose: (choice: PickerChoice) => void;
+
+  constructor(
+    app: App,
+    imageCount: number,
+    onChoose: (choice: PickerChoice) => void,
+  ) {
+    super(app);
+    this.imageCount = imageCount;
+    this.onChoose = onChoose;
+  }
+
+  onOpen() {
+    this.titleEl.setText("Insert image layout");
+    this.component = new LayoutPicker({
+      target: this.contentEl,
+      props: {
+        imageCount: this.imageCount,
+        allowCarousel: true,
+      },
+    });
+    this.component.$on(
+      "layout-selected",
+      (event: CustomEvent<PickerChoice>) => {
+        this.close();
+        this.onChoose(event.detail);
+      },
+    );
+  }
+
+  onClose() {
+    this.component?.$destroy();
+    this.component = null;
+    this.contentEl.empty();
+  }
+}

--- a/test-vault/publish.js
+++ b/test-vault/publish.js
@@ -1,4 +1,4 @@
-const g = {
+const h = {
   a: 2,
   b: 2,
   c: 2,
@@ -9,209 +9,201 @@ const g = {
   h: 3,
   i: 4,
   single: 1
-}, y = (l) => {
-  const a = l.split(`
+}, f = (n) => {
+  const o = n.split(`
 `), e = {
     data: {},
-    content: l
+    content: n
   };
-  if (a[0] !== "---")
+  if (o[0] !== "---")
     return e;
-  const n = a.slice(1).findIndex((o) => o === "---") + 1;
-  return n === 0 || (a.slice(1, n).join(`
+  const t = o.slice(1).findIndex((l) => l === "---") + 1;
+  return t === 0 || (o.slice(1, t).join(`
 `).split(`
-`).forEach((o) => {
-    const [d, ...p] = o.split(":").map((u) => u.trim()), m = p.join(":").trim();
+`).forEach((l) => {
+    const [d, ...p] = l.split(":").map((u) => u.trim()), m = p.join(":").trim().replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1");
     d && m && (m === "true" ? e.data[d] = !0 : m === "false" ? e.data[d] = !1 : e.data[d] = m);
-  }), e.content = a.slice(n + 1).join(`
+  }), e.content = o.slice(t + 1).join(`
 `)), e;
-}, w = (l) => {
-  const a = l.match(/\[([^\]]*)\]\(([^\(]*)\)/);
-  if (a) {
-    const [e, n, c] = a;
-    return { url: c, alt: n };
+}, k = (n) => {
+  const o = n.match(/\[([^\]]*)\]\(([^\(]*)\)/);
+  if (o) {
+    const [e, t, s] = o;
+    return { url: s, alt: t };
   }
   return null;
-}, f = (l) => l.split(`
-`).filter((n) => n.startsWith("!")).map((n) => w(n.slice(1))).filter((n) => n !== null);
+}, y = (n) => n.split(`
+`).filter((t) => t.startsWith("!")).map((t) => k(t.slice(1))).filter((t) => t !== null);
 console.log("Image Layouts loading...");
-function v(l, a, e) {
-  const n = document.createElement("div");
-  n.className = `image-layouts image-layouts-grid image-layouts-layout-${a}`;
-  const c = g[a];
-  if ((l.length < c ? [
-    ...l,
-    ...Array(c - l.length).fill({
+function v(n, o, e) {
+  const t = document.createElement("div");
+  t.className = `image-layouts image-layouts-grid image-layouts-layout-${o}`;
+  const s = h[o];
+  if ((n.length < s ? [
+    ...n,
+    ...Array(s - n.length).fill({
       url: "https://via.placeholder.com/640x480"
     })
-  ] : l.slice(0, c)).forEach((o, d) => {
+  ] : n.slice(0, s)).forEach((l, d) => {
     var u;
     const p = document.createElement("div");
     p.className = `group relative image-layouts-image-${d}`;
     const m = document.createElement("img");
-    if (m.src = o.url, m.alt = o.alt || `Image ${d + 1}`, m.className = "w-full h-full object-cover object-center", o.alt || e.descriptions && e.descriptions[d]) {
-      const s = ((u = e.descriptions) == null ? void 0 : u[d]) || o.alt, r = document.createElement("div");
+    if (m.src = l.url, m.alt = l.alt || `Image ${d + 1}`, m.className = "w-full h-full object-cover object-center", l.alt || e.descriptions && e.descriptions[d]) {
+      const c = ((u = e.descriptions) == null ? void 0 : u[d]) || l.alt, r = document.createElement("div");
       r.className = "absolute bottom-0 left-0 right-0 flex items-end p-4", r.setAttribute("aria-hidden", "true"), e.permanentOverlay || r.classList.add("opacity-0", "group-hover:opacity-100");
       const i = document.createElement("div");
-      i.className = "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter", i.textContent = s, r.appendChild(i), p.appendChild(r);
+      i.className = "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter", i.textContent = c, r.appendChild(i), p.appendChild(r);
     }
-    p.appendChild(m), n.appendChild(p);
+    p.appendChild(m), t.appendChild(p);
   }), e.caption) {
-    const o = document.createElement("div");
-    o.className = "text-center mt-2 text-sm text-gray-600", o.textContent = e.caption, n.appendChild(o);
+    const l = document.createElement("div");
+    l.className = "text-center mt-2 text-sm text-gray-600", l.textContent = e.caption, t.appendChild(l);
   }
-  return n;
+  return t;
 }
-function b(l, a, e) {
-  const n = document.createElement("div");
-  n.className = `image-layouts-masonry-grid-${a}`;
-  const c = Array(a).fill(null).map(() => {
-    const t = document.createElement("div");
-    return t.className = "image-layouts-masonry-column", t;
+function b(n, o, e) {
+  const t = document.createElement("div");
+  t.className = `image-layouts-masonry-grid-${o}`;
+  const s = Array(o).fill(null).map(() => {
+    const a = document.createElement("div");
+    return a.className = "image-layouts-masonry-column", a;
   });
-  if (l.forEach((t, o) => {
+  if (n.forEach((a, l) => {
     var u;
-    const d = o % a, p = document.createElement("div");
+    const d = l % o, p = document.createElement("div");
     p.className = "group relative";
     const m = document.createElement("img");
-    if (m.src = t.url, m.alt = t.alt || `Image ${o + 1}`, m.className = "w-full h-full object-cover object-center", t.alt || e.descriptions && e.descriptions[o]) {
-      const s = ((u = e.descriptions) == null ? void 0 : u[o]) || t.alt, r = document.createElement("div");
+    if (m.src = a.url, m.alt = a.alt || `Image ${l + 1}`, m.className = "w-full h-full object-cover object-center", a.alt || e.descriptions && e.descriptions[l]) {
+      const c = ((u = e.descriptions) == null ? void 0 : u[l]) || a.alt, r = document.createElement("div");
       r.className = "absolute bottom-0 left-0 right-0 flex items-end p-4", r.setAttribute("aria-hidden", "true"), e.permanentOverlay || r.classList.add("opacity-0", "group-hover:opacity-100");
       const i = document.createElement("div");
-      i.className = "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter", i.textContent = s, r.appendChild(i), p.appendChild(r);
+      i.className = "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter", i.textContent = c, r.appendChild(i), p.appendChild(r);
     }
-    p.appendChild(m), c[d].appendChild(p);
-  }), c.forEach((t) => n.appendChild(t)), e.caption) {
-    const t = document.createElement("div");
-    t.className = "text-center mt-2 text-sm text-gray-600", t.textContent = e.caption, n.appendChild(t);
+    p.appendChild(m), s[d].appendChild(p);
+  }), s.forEach((a) => t.appendChild(a)), e.caption) {
+    const a = document.createElement("div");
+    a.className = "text-center mt-2 text-sm text-gray-600", a.textContent = e.caption, t.appendChild(a);
   }
-  return n;
+  return t;
 }
-function C(l, a) {
+function w(n, o) {
   const e = document.createElement("div");
   e.className = "image-layout-carousel";
-  const n = document.createElement("div");
-  n.className = "slides-container";
-  for (const [s, r] of l.entries()) {
+  const t = document.createElement("div");
+  t.className = "slides-container";
+  for (const [c, r] of n.entries()) {
     const i = document.createElement("div");
-    i.className = `slide${s === 0 ? " active" : ""}`;
-    const h = document.createElement("img");
-    h.src = r.url, h.alt = r.alt || `Image ${s + 1}`, i.appendChild(h), n.appendChild(i);
+    i.className = `slide${c === 0 ? " active" : ""}`;
+    const g = document.createElement("img");
+    g.src = r.url, g.alt = r.alt || `Image ${c + 1}`, i.appendChild(g), t.appendChild(i);
   }
-  const c = document.createElement("button");
-  c.className = "nav-button prev", c.innerHTML = `
+  const s = document.createElement("button");
+  s.className = "nav-button prev", s.innerHTML = `
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
     </svg>
   `;
-  const t = document.createElement("button");
-  t.className = "nav-button next", t.innerHTML = `
+  const a = document.createElement("button");
+  a.className = "nav-button next", a.innerHTML = `
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
     </svg>
   `;
-  let o = 0;
-  function d(s) {
+  let l = 0;
+  function d(c) {
     const r = Array.from(
-      n.getElementsByClassName("slide")
+      t.getElementsByClassName("slide")
     );
-    if (r[o].classList.remove("active"), r[s].classList.add("active"), u) {
+    if (r[l].classList.remove("active"), r[c].classList.add("active"), u) {
       const i = Array.from(
         u.getElementsByTagName("img")
       );
-      i[o].classList.remove("active"), i[s].classList.add("active"), i[s].scrollIntoView({
+      i[l].classList.remove("active"), i[c].classList.add("active"), i[c].scrollIntoView({
         behavior: "smooth",
         block: "nearest",
         inline: "center"
       });
     }
-    o = s;
+    l = c;
   }
   function p() {
-    const s = (o + 1) % l.length;
-    d(s);
+    const c = (l + 1) % n.length;
+    d(c);
   }
   function m() {
-    const s = (o - 1 + l.length) % l.length;
-    d(s);
+    const c = (l - 1 + n.length) % n.length;
+    d(c);
   }
-  t.onclick = p, c.onclick = m, e.tabIndex = 0, e.onkeydown = (s) => {
-    s.key === "ArrowLeft" && m(), s.key === "ArrowRight" && p();
+  a.onclick = p, s.onclick = m, e.tabIndex = 0, e.onkeydown = (c) => {
+    c.key === "ArrowLeft" && m(), c.key === "ArrowRight" && p();
   };
   let u;
-  if (a) {
+  if (o) {
     u = document.createElement("div"), u.className = "thumbnails-container";
-    for (let s = 0; s < l.length; s++) {
+    for (let c = 0; c < n.length; c++) {
       const r = document.createElement("div");
       r.className = "thumbnail-item";
       const i = document.createElement("img");
-      i.src = l[s].url, i.alt = l[s].alt || `Thumbnail ${s + 1}`, s === 0 && i.classList.add("active"), i.onclick = () => d(s), r.appendChild(i), u.appendChild(r);
+      i.src = n[c].url, i.alt = n[c].alt || `Thumbnail ${c + 1}`, c === 0 && i.classList.add("active"), i.onclick = () => d(c), r.appendChild(i), u.appendChild(r);
     }
   }
-  return e.appendChild(n), e.appendChild(c), e.appendChild(t), u && e.appendChild(u), e;
+  return e.appendChild(t), e.appendChild(s), e.appendChild(a), u && e.appendChild(u), e;
 }
-publish.registerMarkdownCodeBlockProcessor("image-layout", (l, a) => {
-  console.log("Processing image-layout block:", { source: l });
-  const { data: e, content: n } = y(l), c = f(n);
+publish.registerMarkdownCodeBlockProcessor("image-layout", (n, o) => {
+  console.log("Processing image-layout block:", { source: n });
+  const { data: e, content: t } = f(n), s = y(t);
   if (!e.layout) {
     console.error("No layout specified in front matter");
     return;
   }
-  for (console.log("Parsed config:", { data: e, images: c }); a.firstChild; )
-    a.removeChild(a.firstChild);
-  if (e.layout === "carousel") {
-    console.log("Creating carousel with thumbnails:", e.showThumbnails);
-    const t = C(c, e.showThumbnails !== !1);
-    a.appendChild(t);
-  } else if (e.layout.match(/^legacy-layout-[a-i]$/)) {
-    const t = e.layout.charAt(e.layout.length - 1);
-    if (g[t]) {
-      const o = v(c, t, e);
-      a.appendChild(o);
-    }
-  } else if (e.layout.match(/^legacy-masonry-[2-6]$/)) {
-    const t = parseInt(e.layout.charAt(e.layout.length - 1));
-    if (t >= 2 && t <= 6) {
-      const o = b(c, t, e);
-      a.appendChild(o);
-    }
-  }
+  for (console.log("Parsed config:", { data: e, images: s }); o.firstChild; )
+    o.removeChild(o.firstChild);
+  const a = C(String(e.layout), s, e);
+  a && o.appendChild(a);
 });
-Object.keys(g).forEach((l) => {
+function C(n, o, e) {
+  const t = n.startsWith("legacy-layout-") ? n.slice(14) : n.startsWith("legacy-masonry-") ? `masonry-${n.slice(15)}` : n;
+  if (t === "carousel")
+    return w(o, e.showThumbnails !== !1);
+  const s = t.match(/^masonry-([2-6])$/);
+  return s ? b(o, parseInt(s[1]), e) : h[t] ? v(o, t, e) : null;
+}
+Object.keys(h).forEach((n) => {
   publish.registerMarkdownCodeBlockProcessor(
-    `image-layout-${l}`,
-    (a, e) => {
-      const { data: n, content: c } = y(a), t = f(c), o = v(t, l, n);
-      e.replaceChildren(o);
+    `image-layout-${n}`,
+    (o, e) => {
+      const { data: t, content: s } = f(o), a = y(s), l = v(a, n, t);
+      e.replaceChildren(l);
     }
   );
 });
-for (let l = 2; l <= 6; l++)
+for (let n = 2; n <= 6; n++)
   publish.registerMarkdownCodeBlockProcessor(
-    `image-layout-masonry-${l}`,
-    (a, e) => {
-      const { data: n, content: c } = y(a), t = f(c), o = b(t, l, n);
-      e.replaceChildren(o);
+    `image-layout-masonry-${n}`,
+    (o, e) => {
+      const { data: t, content: s } = f(o), a = y(s), l = b(a, n, t);
+      e.replaceChildren(l);
     }
   );
 console.log("Image Layouts loaded");
 document.addEventListener("DOMContentLoaded", () => {
   console.log("Processing existing image-layout blocks");
-  const l = document.querySelectorAll("pre > code.language-image-layout");
-  console.log("Found blocks:", l.length);
-  for (const a of l) {
-    const e = a.textContent || "", { data: n, content: c } = y(e), t = f(c);
-    if (console.log("Processing block:", { data: n, images: t }), t.length > 0) {
-      let o;
-      if (a.className.includes("language-image-layout-masonry-")) {
-        const d = parseInt(a.className.split("-").pop() || "2");
-        o = b(t, d, n);
-      } else if (a.className.includes("language-image-layout-")) {
-        const d = a.className.split("-").pop();
-        g[d] && (o = v(t, d, n));
+  const n = document.querySelectorAll("pre > code.language-image-layout");
+  console.log("Found blocks:", n.length);
+  for (const o of n) {
+    const e = o.textContent || "", { data: t, content: s } = f(e), a = y(s);
+    if (console.log("Processing block:", { data: t, images: a }), a.length > 0) {
+      let l;
+      if (o.className.includes("language-image-layout-masonry-")) {
+        const d = parseInt(o.className.split("-").pop() || "2");
+        l = b(a, d, t);
+      } else if (o.className.includes("language-image-layout-")) {
+        const d = o.className.split("-").pop();
+        h[d] && (l = v(a, d, t));
       } else
-        n.layout === "carousel" && (o = C(t, n.showThumbnails !== !1));
-      o && a.parentElement && (console.log("Replacing block with layout"), a.parentElement.replaceWith(o));
+        t.layout && (l = C(String(t.layout), a, t));
+      l && o.parentElement && (console.log("Replacing block with layout"), o.parentElement.replaceWith(l));
     }
   }
 });

--- a/test-vault/publish.ts
+++ b/test-vault/publish.ts
@@ -383,24 +383,38 @@ publish.registerMarkdownCodeBlockProcessor("image-layout", (source, el) => {
     el.removeChild(el.firstChild);
   }
 
-  if (data.layout === "carousel") {
-    console.log("Creating carousel with thumbnails:", data.showThumbnails);
-    const carousel = createCarousel(images, data.showThumbnails !== false); // Default to showing thumbnails
-    el.appendChild(carousel);
-  } else if (data.layout.match(/^legacy-layout-[a-i]$/)) {
-    const layoutType = data.layout.charAt(data.layout.length - 1) as LayoutType;
-    if (layoutImages[layoutType]) {
-      const grid = createLegacyGridLayout(images, layoutType, data);
-      el.appendChild(grid);
-    }
-  } else if (data.layout.match(/^legacy-masonry-[2-6]$/)) {
-    const columns = parseInt(data.layout.charAt(data.layout.length - 1));
-    if (columns >= 2 && columns <= 6) {
-      const masonry = createMasonryLayout(images, columns, data);
-      el.appendChild(masonry);
-    }
+  const layout = createModernLayout(String(data.layout), images, data);
+  if (layout) {
+    el.appendChild(layout);
   }
 });
+
+// Renders the modern image-layout block's layout value, accepting every
+// form the app writes: carousel, bare grid names (a-i, single), masonry-N,
+// and the older legacy-layout-* / legacy-masonry-* spellings.
+function createModernLayout(
+  layoutValue: string,
+  images: ImageLink[],
+  data: FrontMatter,
+): HTMLElement | null {
+  const normalized = layoutValue.startsWith("legacy-layout-")
+    ? layoutValue.slice("legacy-layout-".length)
+    : layoutValue.startsWith("legacy-masonry-")
+      ? `masonry-${layoutValue.slice("legacy-masonry-".length)}`
+      : layoutValue;
+
+  if (normalized === "carousel") {
+    return createCarousel(images, data.showThumbnails !== false); // Default to showing thumbnails
+  }
+  const masonry = normalized.match(/^masonry-([2-6])$/);
+  if (masonry) {
+    return createMasonryLayout(images, parseInt(masonry[1]), data);
+  }
+  if (layoutImages[normalized as LayoutType]) {
+    return createLegacyGridLayout(images, normalized as LayoutType, data);
+  }
+  return null;
+}
 
 // Register legacy layout processors for backward compatibility
 Object.keys(layoutImages).forEach((layout) => {
@@ -453,8 +467,8 @@ document.addEventListener("DOMContentLoaded", () => {
         if (layoutImages[layoutType]) {
           layout = createLegacyGridLayout(images, layoutType, data);
         }
-      } else if (data.layout === "carousel") {
-        layout = createCarousel(images, data.showThumbnails !== false); // Default to showing thumbnails
+      } else if (data.layout) {
+        layout = createModernLayout(String(data.layout), images, data);
       }
 
       if (layout && block.parentElement) {

--- a/test/blocks.test.ts
+++ b/test/blocks.test.ts
@@ -3,6 +3,7 @@ import {
   buildLayoutBlock,
   parseMasonryLayoutName,
   replaceFenceLayout,
+  updateLayoutInBlockSource,
 } from "../src/utils/blocks.ts";
 
 test("parseMasonryLayoutName accepts masonry-2 through masonry-6", () => {
@@ -52,4 +53,69 @@ test("buildLayoutBlock with carousel thumbnails and empty content", () => {
   expect(block).toBe(
     "```image-layout\n---\nlayout: carousel\ncarouselShowThumbnails: true\n---\n```\n",
   );
+});
+
+test("updateLayoutInBlockSource preserves comments, formatting, and key order", () => {
+  const source = [
+    "---",
+    "# my favourite photos",
+    "caption: Summer",
+    "layout: a",
+    "descriptions:",
+    "- first",
+    "- second",
+    "---",
+    "![[one.jpg]]",
+    "![[two.jpg]]",
+    "",
+  ].join("\n");
+  const updated = updateLayoutInBlockSource(source, { type: "masonry-3" });
+  expect(updated).toBe(
+    [
+      "---",
+      "# my favourite photos",
+      "caption: Summer",
+      "layout: masonry-3",
+      "descriptions:",
+      "- first",
+      "- second",
+      "---",
+      "![[one.jpg]]",
+      "![[two.jpg]]",
+      "",
+    ].join("\n"),
+  );
+});
+
+test("updateLayoutInBlockSource adds a layout line when frontmatter has none", () => {
+  const source = "---\ncaption: Hi\n---\n![[a.jpg]]\n";
+  expect(updateLayoutInBlockSource(source, { type: "b" })).toBe(
+    "---\ncaption: Hi\nlayout: b\n---\n![[a.jpg]]\n",
+  );
+});
+
+test("updateLayoutInBlockSource prepends frontmatter when there is none", () => {
+  expect(updateLayoutInBlockSource("![[a.jpg]]", { type: "single" })).toBe(
+    "---\nlayout: single\n---\n![[a.jpg]]\n",
+  );
+});
+
+test("updateLayoutInBlockSource manages the carousel thumbnails line", () => {
+  const withThumbs = updateLayoutInBlockSource("---\nlayout: a\n---\n", {
+    type: "carousel",
+    params: { showThumbnails: true },
+  });
+  expect(withThumbs).toBe(
+    "---\nlayout: carousel\ncarouselShowThumbnails: true\n---\n",
+  );
+  const backToPills = updateLayoutInBlockSource(withThumbs, {
+    type: "carousel",
+  });
+  expect(backToPills).toBe("---\nlayout: carousel\n---\n");
+});
+
+test("buildLayoutBlock lengthens its fence past backtick runs in the content", () => {
+  const block = buildLayoutBlock({ type: "a" }, "```js\ncode\n```");
+  expect(block.startsWith("````image-layout\n")).toBe(true);
+  expect(block.endsWith("\n````\n")).toBe(true);
 });

--- a/test/blocks.test.ts
+++ b/test/blocks.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "vitest";
+import {
+  buildLayoutBlock,
+  parseMasonryLayoutName,
+  replaceFenceLayout,
+} from "../src/utils/blocks.ts";
+
+test("parseMasonryLayoutName accepts masonry-2 through masonry-6", () => {
+  expect(parseMasonryLayoutName("masonry-2")).toBe(2);
+  expect(parseMasonryLayoutName("masonry-6")).toBe(6);
+  expect(parseMasonryLayoutName("masonry-7")).toBeNull();
+  expect(parseMasonryLayoutName("masonry-1")).toBeNull();
+  expect(parseMasonryLayoutName("carousel")).toBeNull();
+  expect(parseMasonryLayoutName("a")).toBeNull();
+});
+
+test("replaceFenceLayout renames legacy fence tokens", () => {
+  expect(replaceFenceLayout("```image-layout-a", "b")).toBe("```image-layout-b");
+  expect(replaceFenceLayout("```image-layout-masonry-3", "a")).toBe(
+    "```image-layout-a",
+  );
+  expect(replaceFenceLayout("```image-layout-left", "masonry-4")).toBe(
+    "```image-layout-masonry-4",
+  );
+  expect(replaceFenceLayout("````image-layout-h", "i")).toBe(
+    "````image-layout-i",
+  );
+});
+
+test("replaceFenceLayout rejects non-fence lines", () => {
+  expect(replaceFenceLayout("![[image.jpg]]", "a")).toBeNull();
+  expect(replaceFenceLayout("```image-layout", "a")).toBeNull();
+  expect(replaceFenceLayout("```python", "a")).toBeNull();
+  expect(replaceFenceLayout("text ```image-layout-a", "a")).toBeNull();
+});
+
+test("buildLayoutBlock wraps selected content", () => {
+  const block = buildLayoutBlock(
+    { type: "a" },
+    "![[one.jpg]]\n![[two.jpg]]",
+  );
+  expect(block).toBe(
+    "```image-layout\n---\nlayout: a\n---\n![[one.jpg]]\n![[two.jpg]]\n```\n",
+  );
+});
+
+test("buildLayoutBlock with carousel thumbnails and empty content", () => {
+  const block = buildLayoutBlock({
+    type: "carousel",
+    params: { showThumbnails: true },
+  });
+  expect(block).toBe(
+    "```image-layout\n---\nlayout: carousel\ncarouselShowThumbnails: true\n---\n```\n",
+  );
+});


### PR DESCRIPTION
## Summary

You never need to memorize a layout letter again.

- **Visual picker**: an empty `image-layout` block now shows *every* layout (grids a–i, single, masonry 2–6, both carousel variants) as theme-aware visual schematics. Layouts matching the block's current image count get highlighted. The old picker offered only two carousel cards in hardcoded light-theme colors.
- **Change layout in place**: rendered blocks grow a hover button that reopens the picker. Modern blocks rewrite `layout:` in frontmatter; legacy blocks rename their fence token (`image-layout-a` → `image-layout-masonry-3`) so documents keep their format. Failure paths (embeds/exports where the block position can't be resolved) show a Notice instead of silently no-oping.
- **Insert image layout** command: modal picker, inserts at cursor, wraps selected image lines. Works in source mode and on mobile.
- Modern `image-layout` blocks render masonry now (`layout: masonry-N`), making the modern block a superset of all layouts.

Grid templates moved to `interfaces.ts` as data so picker schematics and layouts share one definition. 42 unit tests (fence renaming, block building, masonry name parsing added).

https://claude.ai/code/session_01C3XcBQRGY2q7CmFSvYM4WY