### PR TITLE
0.18.0: custom ASCII-grid layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.18.0
+
+### Added
+
+- **Custom layouts** (#15): `layout: custom` with an ASCII-art `grid` —
+  rows of letters where equal letters merge into one region and `.` leaves
+  a cell empty:
+
+  ```
+  layout: custom
+  grid: |
+    A A B
+    A A C
+  ```
+
+  Letters map to your images in order of first appearance. Invalid grids
+  (ragged rows, non-rectangular regions) render a friendly message instead
+  of nothing. The picker gets a "custom" tile that seeds a starter grid,
+  and published sites render custom layouts too.
+
 ## 0.17.0
 
 You never need to memorize a layout letter again.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ When I find time I'm hoping to add the following:
 - Overlays from markdown links [DONE]
 - General gallery to support scrolling through photos [DONE]
 - Captions from wikilinks, overlay never/hover/always, folder galleries, alignment and fit options [DONE]
-- Visually pick layouts — every layout, in the block and from the command palette [DONE - NEW!]
+- Visually pick layouts — every layout, in the block and from the command palette [DONE]
+- User-definable custom layouts — `layout: custom` with ASCII-art grids [DONE - NEW!]
 - Drag and drop support
-- User-definable custom layouts (#15)
 
 ## Documentation
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -8,8 +8,8 @@ a change-layout button on hover to reopen the picker. There is also an
 current selection.
 
 The modern `image-layout` block accepts `layout: a` … `layout: i`,
-`layout: single`, `layout: masonry-2` … `layout: masonry-6`, or
-`layout: carousel`.
+`layout: single`, `layout: masonry-2` … `layout: masonry-6`,
+`layout: carousel`, or `layout: custom`.
 
 Every layout block accepts options as YAML front matter inside the codeblock:
 
@@ -77,6 +77,30 @@ shorthands for a single image aligned to that side:
 
 Per-image captions (from `![[image.jpg|caption]]`, markdown alt text, or
 `descriptions`) are shown under the current slide.
+
+## Custom layouts (`layout: custom`)
+
+Design your own grid with rows of letters — equal letters merge into one
+region, `.` leaves a cell empty, and letters map to your images in order of
+first appearance:
+
+````
+```image-layout
+---
+layout: custom
+grid: |
+  A A B
+  A A C
+---
+![[hero.jpg]]
+![[detail-1.jpg]]
+![[detail-2.jpg]]
+```
+````
+
+Rows must all have the same number of cells and each letter's cells must form
+a solid rectangle (that's a CSS grid rule). Custom layouts support `caption`,
+`descriptions`, `overlay`, `fit`, and `fromFolder` like any grid.
 
 ## Populating from a folder
 

--- a/src/components/CustomGridLayout.svelte
+++ b/src/components/CustomGridLayout.svelte
@@ -3,7 +3,7 @@
   import type { OverlayMode } from "../types";
   import type { CustomGrid } from "../utils/custom-grid";
   import type { ReadyImageLink } from "../utils/images";
-  import { PLACEHOLDER_DATA_URI } from "../utils/placeholder";
+  import { PLACEHOLDER_DATA_URI, padToSlots } from "../utils/placeholder";
   import Caption from "./Caption.svelte";
   import LegacyGridImage from "./LegacyGridImage.svelte";
 
@@ -15,19 +15,7 @@
   export let fit: FitMode = "cover";
   export let placeholderUrl: string = PLACEHOLDER_DATA_URI;
 
-  let displayImages: ReadyImageLink[] = [];
-
-  if (images.length < grid.slots) {
-    displayImages = [
-      ...images,
-      ...Array(grid.slots - images.length).fill({
-        type: "external",
-        link: placeholderUrl,
-      }),
-    ];
-  } else {
-    displayImages = images.slice(0, grid.slots);
-  }
+  $: displayImages = padToSlots(images, grid.slots, placeholderUrl);
 </script>
 
 <div

--- a/src/components/CustomGridLayout.svelte
+++ b/src/components/CustomGridLayout.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import type { FitMode } from "../interfaces";
+  import type { OverlayMode } from "../types";
+  import type { CustomGrid } from "../utils/custom-grid";
+  import type { ReadyImageLink } from "../utils/images";
+  import { PLACEHOLDER_DATA_URI } from "../utils/placeholder";
+  import Caption from "./Caption.svelte";
+  import LegacyGridImage from "./LegacyGridImage.svelte";
+
+  export let grid: CustomGrid;
+  export let images: ReadyImageLink[] = [];
+  export let caption: string = "";
+  export let descriptions: (string | undefined)[] = [];
+  export let overlayMode: OverlayMode = "hover";
+  export let fit: FitMode = "cover";
+  export let placeholderUrl: string = PLACEHOLDER_DATA_URI;
+
+  let displayImages: ReadyImageLink[] = [];
+
+  if (images.length < grid.slots) {
+    displayImages = [
+      ...images,
+      ...Array(grid.slots - images.length).fill({
+        type: "external",
+        link: placeholderUrl,
+      }),
+    ];
+  } else {
+    displayImages = images.slice(0, grid.slots);
+  }
+</script>
+
+<div
+  class="image-layouts image-layouts-grid image-layouts-custom cursor-default"
+  class:fit-natural={fit === "natural"}
+  style:grid-template-columns={`repeat(${grid.columns}, 1fr)`}
+  style:grid-template-areas={grid.templateAreas}
+>
+  {#each displayImages as image, index}
+    <LegacyGridImage
+      {index}
+      src={image.link}
+      description={descriptions[index] ?? image.alt}
+      width={image.width}
+      gridArea={`image-${index}`}
+      {overlayMode}
+      {fit}
+    />
+  {/each}
+</div>
+<Caption {caption} />
+
+<style>
+  .image-layouts-custom {
+    display: grid;
+    grid-gap: 0.5rem;
+  }
+
+  .image-layouts-custom.fit-natural {
+    align-items: start;
+  }
+</style>

--- a/src/components/ErrorMessage.svelte
+++ b/src/components/ErrorMessage.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  export let message: string;
+</script>
+
+<div class="image-layouts-error">{message}</div>
+
+<style>
+  .image-layouts-error {
+    color: var(--text-muted);
+    font-size: 0.85em;
+    padding: 0.5rem;
+    border: 1px dashed var(--background-modifier-border);
+    border-radius: 6px;
+    white-space: pre-wrap;
+  }
+</style>

--- a/src/components/LayoutPicker.svelte
+++ b/src/components/LayoutPicker.svelte
@@ -11,8 +11,9 @@
   // many are highlighted.
   export let imageCount: number = 0;
   // Legacy blocks can only be renamed to other legacy fences, which have no
-  // carousel form.
+  // carousel or custom form.
   export let allowCarousel: boolean = true;
+  export let allowCustom: boolean = true;
   // Set when switching an existing block, to mark the current layout.
   export let currentLayout: string | undefined = undefined;
   export let showCancel: boolean = false;
@@ -65,6 +66,19 @@
         >
       </button>
     {/each}
+    {#if allowCustom}
+      <button
+        type="button"
+        class="tile"
+        class:current={currentLayout === "custom"}
+        aria-label="Custom grid layout"
+        title="Design your own grid with rows of letters"
+        on:click={() => select("custom")}
+      >
+        <LayoutSchematic custom={true} />
+        <span class="tile-label">custom</span>
+      </button>
+    {/if}
   </div>
 
   <div class="picker-section">Masonry</div>

--- a/src/components/LayoutSchematic.svelte
+++ b/src/components/LayoutSchematic.svelte
@@ -10,6 +10,8 @@
   export let grid: LayoutType | undefined = undefined;
   export let masonryColumns: number | undefined = undefined;
   export let carousel: "pills" | "thumbnails" | undefined = undefined;
+  // The "design your own" tile: a hero region plus two stacked cells.
+  export let custom: boolean = false;
 
   // Alternating block heights give the masonry schematic its stagger.
   const masonryHeights = [
@@ -55,6 +57,16 @@
         {/if}
       </div>
     </div>
+  {:else if custom}
+    <div
+      class="schematic-grid"
+      style:grid-template-columns="2fr 1fr"
+      style:grid-template-areas={'"hero top" "hero bottom"'}
+    >
+      <div class="cell dashed" style:grid-area="hero"></div>
+      <div class="cell dashed" style:grid-area="top"></div>
+      <div class="cell dashed" style:grid-area="bottom"></div>
+    </div>
   {/if}
 </div>
 
@@ -68,6 +80,11 @@
   .cell {
     background-color: var(--background-modifier-border);
     border-radius: 2px;
+  }
+
+  .cell.dashed {
+    background-color: transparent;
+    border: 1px dashed var(--text-muted);
   }
 
   .schematic-grid {

--- a/src/components/LegacyGridImage.svelte
+++ b/src/components/LegacyGridImage.svelte
@@ -8,6 +8,9 @@
   export let overlayMode: OverlayMode = "hover";
   export let fit: FitMode = "cover";
   export let width: number | undefined = undefined;
+  // Custom layouts place images by inline grid-area (the class-based areas
+  // below only exist for indexes 0-6).
+  export let gridArea: string | undefined = undefined;
 </script>
 
 <div
@@ -15,6 +18,7 @@
   class:fit-contain={fit === "contain"}
   class:fit-natural={fit === "natural"}
   style:max-width={width ? `${width}px` : undefined}
+  style:grid-area={gridArea}
 >
   <img {src} alt={description ?? `Image ${index + 1}`} />
   {#if description && overlayMode !== "never"}

--- a/src/components/LegacyImageLayout.svelte
+++ b/src/components/LegacyImageLayout.svelte
@@ -2,7 +2,7 @@
   import type { AlignMode, FitMode, LayoutType } from "../interfaces";
   import type { OverlayMode } from "../types";
   import type { ReadyImageLink } from "../utils/images";
-  import { PLACEHOLDER_DATA_URI } from "../utils/placeholder";
+  import { PLACEHOLDER_DATA_URI, padToSlots } from "../utils/placeholder";
   import Caption from "./Caption.svelte";
   import LegacyGridImage from "./LegacyGridImage.svelte";
 
@@ -17,21 +17,9 @@
   export let width: number | string | undefined = undefined;
   export let placeholderUrl: string = PLACEHOLDER_DATA_URI;
 
-  let displayImages: ReadyImageLink[] = [];
-
   // If there are fewer images than the layout needs, fill the remaining
   // slots with the placeholder.
-  if (images.length < requiredImages) {
-    displayImages = [
-      ...images,
-      ...Array(requiredImages - images.length).fill({
-        type: "external",
-        link: placeholderUrl,
-      }),
-    ];
-  } else {
-    displayImages = images.slice(0, requiredImages);
-  }
+  $: displayImages = padToSlots(images, requiredImages, placeholderUrl);
 
   const widthStyle = typeof width === "number" ? `${width}px` : width;
 </script>

--- a/src/components/SwitchableLayout.svelte
+++ b/src/components/SwitchableLayout.svelte
@@ -9,6 +9,7 @@
   export let switchable: boolean = false;
   export let imageCount: number = 0;
   export let allowCarousel: boolean = true;
+  export let allowCustom: boolean = true;
   export let currentLayout: string | undefined = undefined;
 
   const dispatch = createEventDispatcher();
@@ -24,6 +25,7 @@
   <LayoutPicker
     {imageCount}
     {allowCarousel}
+    {allowCustom}
     {currentLayout}
     showCancel={true}
     on:layout-selected={apply}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -80,6 +80,7 @@ export type LayoutBlockOptions = {
 // Extra options understood by the modern `image-layout` block.
 export type ImageLayoutBlockOptions = LayoutBlockOptions & {
   layout?: string;
+  grid?: string;
   carouselShowThumbnails?: boolean;
   carouselBackground?: string;
   carouselHeight?: number | string;

--- a/src/processors/image-layout.ts
+++ b/src/processors/image-layout.ts
@@ -1,5 +1,6 @@
 import CarouselComponent from "../components/Carousel.svelte";
 import CustomGridLayout from "../components/CustomGridLayout.svelte";
+import ErrorMessage from "../components/ErrorMessage.svelte";
 import LayoutPickerComponent from "../components/LayoutPicker.svelte";
 import LegacyLayoutComponent from "../components/LegacyImageLayout.svelte";
 import LegacyMasonryLayout from "../components/LegacyMasonryLayout.svelte";
@@ -119,11 +120,12 @@ export function renderImageLayoutComponent(
   if (layout === "custom") {
     const parsed = parseCustomGrid(m.data.grid);
     if (parsed.error) {
-      const errorEl = parent.createDiv({ cls: "image-layouts-error" });
-      errorEl.setText(`Image Layouts: ${parsed.error}`);
-      errorEl.setAttr(
-        "style",
-        "color: var(--text-muted); font-size: 0.85em; padding: 0.5rem; border: 1px dashed var(--background-modifier-border); border-radius: 6px; white-space: pre-wrap;",
+      // Mounted switchable so the change-layout button still offers a way
+      // out of a broken grid without hand-editing YAML.
+      mountSwitchable(
+        ErrorMessage,
+        { message: `Image Layouts: ${parsed.error}` },
+        "custom",
       );
       return;
     }

--- a/src/processors/image-layout.ts
+++ b/src/processors/image-layout.ts
@@ -1,4 +1,5 @@
 import CarouselComponent from "../components/Carousel.svelte";
+import CustomGridLayout from "../components/CustomGridLayout.svelte";
 import LayoutPickerComponent from "../components/LayoutPicker.svelte";
 import LegacyLayoutComponent from "../components/LegacyImageLayout.svelte";
 import LegacyMasonryLayout from "../components/LegacyMasonryLayout.svelte";
@@ -18,6 +19,7 @@ import {
   parseMasonryLayoutName,
   updateLayoutInBlockSource,
 } from "../utils/blocks";
+import { parseCustomGrid } from "../utils/custom-grid";
 import { writeBlockSource } from "../utils/editor-writeback";
 import { parseFrontMatterBlock } from "../utils/front-matter";
 import { normalizeAlign, normalizeDescriptions } from "../utils/options";
@@ -110,6 +112,33 @@ export function renderImageLayoutComponent(
         height: m.data.carouselHeight,
       },
       m.data.carouselShowThumbnails ? "carousel-thumbnails" : "carousel",
+    );
+    return;
+  }
+
+  if (layout === "custom") {
+    const parsed = parseCustomGrid(m.data.grid);
+    if (parsed.error) {
+      const errorEl = parent.createDiv({ cls: "image-layouts-error" });
+      errorEl.setText(`Image Layouts: ${parsed.error}`);
+      errorEl.setAttr(
+        "style",
+        "color: var(--text-muted); font-size: 0.85em; padding: 0.5rem; border: 1px dashed var(--background-modifier-border); border-radius: 6px; white-space: pre-wrap;",
+      );
+      return;
+    }
+    mountSwitchable(
+      CustomGridLayout,
+      {
+        grid: parsed.grid,
+        images: readyImages,
+        caption: m.data.caption ?? "",
+        descriptions,
+        overlayMode: resolveOverlayMode(m.data, plugin.settings),
+        fit: m.data.fit,
+        placeholderUrl: resolvePlaceholderImage(plugin),
+      },
+      "custom",
     );
     return;
   }

--- a/src/processors/legacy-image-layouts.ts
+++ b/src/processors/legacy-image-layouts.ts
@@ -106,6 +106,7 @@ export function renderLegacyLayoutComponent(
       switchable: ctx.getSectionInfo(parent) !== null,
       imageCount: readyImages.length,
       allowCarousel: false,
+      allowCustom: false,
       currentLayout: fenceLayout,
     },
   });

--- a/src/processors/legacy-masory-layouts.ts
+++ b/src/processors/legacy-masory-layouts.ts
@@ -44,6 +44,7 @@ export function renderLegacyMasonryLayoutComponent(
       switchable: ctx.getSectionInfo(parent) !== null,
       imageCount: readyImages.length,
       allowCarousel: false,
+      allowCustom: false,
       currentLayout: `masonry-${columns}`,
     },
   });

--- a/src/utils/blocks.ts
+++ b/src/utils/blocks.ts
@@ -1,4 +1,5 @@
 import type { PickerChoice } from "../interfaces";
+import { STARTER_GRID_LINES } from "./custom-grid";
 
 // `layout: masonry-3` → 3; null for anything that isn't a masonry layout name.
 export const parseMasonryLayoutName = (layout: string): number | null => {
@@ -62,15 +63,26 @@ export const updateLayoutInBlockSource = (
       } else if (choice.type === "carousel" && thumbnailsIndex >= 0) {
         inner.splice(thumbnailsIndex, 1);
       }
+      // Picking Custom seeds a starter grid to edit, unless one exists.
+      if (
+        choice.type === "custom" &&
+        !inner.some((line) => /^\s*grid\s*:/.test(line))
+      ) {
+        inner.push(...STARTER_GRID_LINES);
+      }
       const rest = lines.slice(end + 1).join("\n");
       return `---\n${inner.join("\n")}\n---\n${rest}`;
     }
   }
-  const frontMatter = wantThumbnails
-    ? `---\n${layoutLine}\n${thumbnailsLine}\n---\n`
-    : `---\n${layoutLine}\n---\n`;
+  const frontMatterLines = [layoutLine];
+  if (wantThumbnails) {
+    frontMatterLines.push(thumbnailsLine);
+  }
+  if (choice.type === "custom") {
+    frontMatterLines.push(...STARTER_GRID_LINES);
+  }
   const body = source === "" || source.endsWith("\n") ? source : `${source}\n`;
-  return frontMatter + body;
+  return `---\n${frontMatterLines.join("\n")}\n---\n${body}`;
 };
 
 // Builds a complete modern image-layout codeblock for the insert command.

--- a/src/utils/blocks.ts
+++ b/src/utils/blocks.ts
@@ -43,16 +43,16 @@ export const updateLayoutInBlockSource = (
     if (closing >= 0) {
       const end = closing + 1;
       const inner = lines.slice(1, end);
-      const layoutIndex = inner.findIndex((line) =>
-        /^\s*layout\s*:/.test(line),
-      );
+      // Keys are matched at column 0 only — an indented `layout:` inside a
+      // block scalar (e.g. a multi-line caption) is content, not a key.
+      const layoutIndex = inner.findIndex((line) => /^layout\s*:/.test(line));
       if (layoutIndex >= 0) {
         inner[layoutIndex] = layoutLine;
       } else {
         inner.push(layoutLine);
       }
       const thumbnailsIndex = inner.findIndex((line) =>
-        /^\s*carouselShowThumbnails\s*:/.test(line),
+        /^carouselShowThumbnails\s*:/.test(line),
       );
       if (wantThumbnails) {
         if (thumbnailsIndex >= 0) {
@@ -66,7 +66,7 @@ export const updateLayoutInBlockSource = (
       // Picking Custom seeds a starter grid to edit, unless one exists.
       if (
         choice.type === "custom" &&
-        !inner.some((line) => /^\s*grid\s*:/.test(line))
+        !inner.some((line) => /^grid\s*:/.test(line))
       ) {
         inner.push(...STARTER_GRID_LINES);
       }

--- a/src/utils/custom-grid.ts
+++ b/src/utils/custom-grid.ts
@@ -1,0 +1,103 @@
+// Parses the ASCII-art `grid` option for `layout: custom` blocks into a CSS
+// grid template. Rows are whitespace-separated tokens; equal tokens merge
+// into one region, "." leaves a cell empty:
+//
+//   grid: |
+//     A A B
+//     A A C
+//
+// maps token A → image 1, B → image 2, C → image 3 (order of first
+// appearance) and becomes grid-template-areas.
+
+export type CustomGrid = {
+  columns: number;
+  rows: number;
+  slots: number;
+  templateAreas: string;
+};
+
+export type CustomGridResult =
+  | { grid: CustomGrid; error?: undefined }
+  | { grid?: undefined; error: string };
+
+const MAX_SLOTS = 20;
+
+export function parseCustomGrid(spec: unknown): CustomGridResult {
+  if (typeof spec !== "string" || spec.trim() === "") {
+    return {
+      error:
+        "A custom layout needs a `grid` option with rows of letters, e.g.\ngrid: |\n  A A B\n  A A C",
+    };
+  }
+  const rows = spec
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "")
+    .map((line) => line.split(/\s+/));
+
+  const columns = rows[0].length;
+  if (rows.some((row) => row.length !== columns)) {
+    return { error: "Every row in `grid` must have the same number of cells." };
+  }
+
+  const order: string[] = [];
+  for (const row of rows) {
+    for (const cell of row) {
+      if (cell !== "." && !order.includes(cell)) {
+        order.push(cell);
+      }
+    }
+  }
+  if (order.length === 0) {
+    return { error: "The `grid` needs at least one image cell." };
+  }
+  if (order.length > MAX_SLOTS) {
+    return { error: `\`grid\` supports up to ${MAX_SLOTS} images.` };
+  }
+
+  // CSS grid-template-areas requires each named area to be a solid
+  // rectangle; validate here so a bad grid gets a readable message instead
+  // of the browser silently discarding the whole template.
+  for (const token of order) {
+    let minRow = Number.POSITIVE_INFINITY;
+    let maxRow = -1;
+    let minCol = Number.POSITIVE_INFINITY;
+    let maxCol = -1;
+    let count = 0;
+    for (const [r, row] of rows.entries()) {
+      for (const [c, cell] of row.entries()) {
+        if (cell === token) {
+          minRow = Math.min(minRow, r);
+          maxRow = Math.max(maxRow, r);
+          minCol = Math.min(minCol, c);
+          maxCol = Math.max(maxCol, c);
+          count++;
+        }
+      }
+    }
+    if (count !== (maxRow - minRow + 1) * (maxCol - minCol + 1)) {
+      return { error: `The cells for "${token}" must form a solid rectangle.` };
+    }
+  }
+
+  const templateAreas = rows
+    .map(
+      (row) =>
+        `"${row
+          .map((cell) => (cell === "." ? "." : `image-${order.indexOf(cell)}`))
+          .join(" ")}"`,
+    )
+    .join(" ");
+
+  return {
+    grid: {
+      columns,
+      rows: rows.length,
+      slots: order.length,
+      templateAreas,
+    },
+  };
+}
+
+// The starter grid written when the user picks "Custom" from the picker.
+export const STARTER_GRID_LINES = ["grid: |", "  A A B", "  A A C"];

--- a/src/utils/placeholder.ts
+++ b/src/utils/placeholder.ts
@@ -1,4 +1,5 @@
 import type ImageLayoutsPlugin from "../main";
+import type { ReadyImageLink } from "./images";
 
 // Inline SVG so empty layout slots never hit the network and render offline —
 // the previous default, via.placeholder.com, is defunct and every empty slot
@@ -6,6 +7,25 @@ import type ImageLayoutsPlugin from "../main";
 export const PLACEHOLDER_DATA_URI = `data:image/svg+xml,${encodeURIComponent(
   '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480"><rect width="100%" height="100%" fill="#88888822"/><circle cx="240" cy="170" r="36" fill="#88888855"/><path d="M120 360l110-140 80 95 60-60 130 105z" fill="#88888855"/></svg>',
 )}`;
+
+// Pads a layout's image list with placeholders up to its slot count, or
+// trims the extras.
+export function padToSlots(
+  images: ReadyImageLink[],
+  slots: number,
+  placeholderUrl: string,
+): ReadyImageLink[] {
+  if (images.length >= slots) {
+    return images.slice(0, slots);
+  }
+  return [
+    ...images,
+    ...Array(slots - images.length).fill({
+      type: "external",
+      link: placeholderUrl,
+    }),
+  ];
+}
 
 // The setting accepts an https:// URL, a data: URI, or a vault path (#27).
 export function resolvePlaceholderImage(plugin: ImageLayoutsPlugin): string {

--- a/test-vault/publish.js
+++ b/test-vault/publish.js
@@ -1,4 +1,6 @@
-const h = {
+const $ = `data:image/svg+xml,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480"><rect width="100%" height="100%" fill="#88888822"/><circle cx="240" cy="170" r="36" fill="#88888855"/><path d="M120 360l110-140 80 95 60-60 130 105z" fill="#88888855"/></svg>'
+)}`, f = {
   a: 2,
   b: 2,
   c: 2,
@@ -9,248 +11,253 @@ const h = {
   h: 3,
   i: 4,
   single: 1
-}, f = (l) => {
-  const a = l.split(`
-`), e = {
+}, y = (n) => {
+  const t = n.split(`
+`), o = {
     data: {},
-    content: l
+    content: n
   };
-  if (a[0] !== "---")
-    return e;
-  const t = a.slice(1).findIndex((n) => n === "---") + 1;
-  if (t === 0)
-    return e;
-  const o = a.slice(1, t).join(`
+  if (t[0] !== "---")
+    return o;
+  const e = t.slice(1).findIndex((l) => l === "---") + 1;
+  if (e === 0)
+    return o;
+  const a = t.slice(1, e).join(`
 `).split(`
 `);
-  for (let n = 0; n < o.length; n++) {
-    const p = o[n], [s, ...d] = p.split(":").map((r) => r.trim()), i = d.join(":").trim().replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1");
-    if (s && (i === "|" || i === ">")) {
+  for (let l = 0; l < a.length; l++) {
+    const c = a[l], [i, ...d] = c.split(":").map((r) => r.trim()), m = d.join(":").trim().replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1");
+    if (i && /^[|>][+-]?\d*$/.test(m)) {
       const r = [];
-      for (; n + 1 < o.length && (/^\s/.test(o[n + 1]) || o[n + 1] === ""); )
-        n++, r.push(o[n].trim());
-      e.data[s] = r.join(`
+      for (; l + 1 < a.length && (/^\s/.test(a[l + 1]) || a[l + 1] === ""); )
+        l++, r.push(a[l].trim());
+      o.data[i] = r.join(`
 `);
       continue;
     }
-    s && i && (i === "true" ? e.data[s] = !0 : i === "false" ? e.data[s] = !1 : e.data[s] = i);
+    i && m && (m === "true" ? o.data[i] = !0 : m === "false" ? o.data[i] = !1 : o.data[i] = m);
   }
-  return e.content = a.slice(t + 1).join(`
-`), e;
-}, w = (l) => {
-  const a = l.match(/\[([^\]]*)\]\(([^\(]*)\)/);
-  if (a) {
-    const [e, t, c] = a;
-    return { url: c, alt: t };
+  return o.content = t.slice(e + 1).join(`
+`), o;
+}, M = (n) => {
+  const t = n.match(/\[([^\]]*)\]\(([^\(]*)\)/);
+  if (t) {
+    const [o, e, s] = t;
+    return { url: s, alt: e };
   }
   return null;
-}, y = (l) => l.split(`
-`).filter((t) => t.startsWith("!")).map((t) => w(t.slice(1))).filter((t) => t !== null);
+}, v = (n) => n.split(`
+`).filter((e) => e.startsWith("!")).map((e) => M(e.slice(1))).filter((e) => e !== null);
 console.log("Image Layouts loading...");
-function v(l, a, e) {
-  const t = document.createElement("div");
-  t.className = `image-layouts image-layouts-grid image-layouts-layout-${a}`;
-  const c = h[a];
-  if ((l.length < c ? [
-    ...l,
-    ...Array(c - l.length).fill({
-      url: "https://via.placeholder.com/640x480"
-    })
-  ] : l.slice(0, c)).forEach((n, p) => {
-    var i;
-    const s = document.createElement("div");
-    s.className = `group relative image-layouts-image-${p}`;
-    const d = document.createElement("img");
-    if (d.src = n.url, d.alt = n.alt || `Image ${p + 1}`, d.className = "w-full h-full object-cover object-center", n.alt || e.descriptions && e.descriptions[p]) {
-      const r = ((i = e.descriptions) == null ? void 0 : i[p]) || n.alt, m = document.createElement("div");
-      m.className = "absolute bottom-0 left-0 right-0 flex items-end p-4", m.setAttribute("aria-hidden", "true"), e.permanentOverlay || m.classList.add("opacity-0", "group-hover:opacity-100");
-      const u = document.createElement("div");
-      u.className = "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter", u.textContent = r, m.appendChild(u), s.appendChild(m);
-    }
-    s.appendChild(d), t.appendChild(s);
-  }), e.caption) {
-    const n = document.createElement("div");
-    n.className = "text-center mt-2 text-sm text-gray-600", n.textContent = e.caption, t.appendChild(n);
-  }
-  return t;
+function k(n, t) {
+  return n.length < t ? [
+    ...n,
+    ...Array(t - n.length).fill({ url: $ })
+  ] : n.slice(0, t);
 }
-function b(l, a, e) {
-  const t = document.createElement("div");
-  t.className = `image-layouts-masonry-grid-${a}`;
-  const c = Array(a).fill(null).map(() => {
-    const o = document.createElement("div");
-    return o.className = "image-layouts-masonry-column", o;
-  });
-  if (l.forEach((o, n) => {
-    var i;
-    const p = n % a, s = document.createElement("div");
-    s.className = "group relative";
-    const d = document.createElement("img");
-    if (d.src = o.url, d.alt = o.alt || `Image ${n + 1}`, d.className = "w-full h-full object-cover object-center", o.alt || e.descriptions && e.descriptions[n]) {
-      const r = ((i = e.descriptions) == null ? void 0 : i[n]) || o.alt, m = document.createElement("div");
-      m.className = "absolute bottom-0 left-0 right-0 flex items-end p-4", m.setAttribute("aria-hidden", "true"), e.permanentOverlay || m.classList.add("opacity-0", "group-hover:opacity-100");
-      const u = document.createElement("div");
-      u.className = "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter", u.textContent = r, m.appendChild(u), s.appendChild(m);
-    }
-    s.appendChild(d), c[p].appendChild(s);
-  }), c.forEach((o) => t.appendChild(o)), e.caption) {
-    const o = document.createElement("div");
-    o.className = "text-center mt-2 text-sm text-gray-600", o.textContent = e.caption, t.appendChild(o);
-  }
-  return t;
-}
-function E(l, a) {
+function w(n, t, o) {
+  var l;
   const e = document.createElement("div");
-  e.className = "image-layout-carousel";
-  const t = document.createElement("div");
-  t.className = "slides-container";
-  for (const [r, m] of l.entries()) {
+  e.className = "group relative";
+  const s = document.createElement("img");
+  s.src = n.url, s.alt = n.alt || `Image ${t + 1}`, s.className = "w-full h-full object-cover object-center";
+  const a = ((l = o.descriptions) == null ? void 0 : l[t]) || n.alt;
+  if (a) {
+    const c = document.createElement("div");
+    c.className = "absolute bottom-0 left-0 right-0 flex items-end p-4", c.setAttribute("aria-hidden", "true"), o.permanentOverlay || c.classList.add("opacity-0", "group-hover:opacity-100");
+    const i = document.createElement("div");
+    i.className = "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter", i.textContent = a, c.appendChild(i), e.appendChild(c);
+  }
+  return e.appendChild(s), e;
+}
+function C(n, t) {
+  if (!t.caption)
+    return n;
+  const o = document.createElement("div");
+  o.appendChild(n);
+  const e = document.createElement("div");
+  return e.className = "text-center mt-2 text-sm text-gray-600", e.textContent = t.caption, o.appendChild(e), o;
+}
+function b(n, t, o) {
+  const e = document.createElement("div");
+  return e.className = `image-layouts image-layouts-grid image-layouts-layout-${t}`, k(n, f[t]).forEach((a, l) => {
+    const c = w(a, l, o);
+    c.classList.add(`image-layouts-image-${l}`), e.appendChild(c);
+  }), C(e, o);
+}
+function E(n, t, o) {
+  const e = document.createElement("div");
+  e.className = `image-layouts-masonry-grid-${t}`;
+  const s = Array(t).fill(null).map(() => {
+    const a = document.createElement("div");
+    return a.className = "image-layouts-masonry-column", a;
+  });
+  return n.forEach((a, l) => {
+    const c = l % t;
+    s[c].appendChild(
+      w(a, l, o)
+    );
+  }), s.forEach((a) => e.appendChild(a)), C(e, o);
+}
+function T(n, t) {
+  const o = document.createElement("div");
+  o.className = "image-layout-carousel";
+  const e = document.createElement("div");
+  e.className = "slides-container";
+  for (const [r, g] of n.entries()) {
     const u = document.createElement("div");
     u.className = `slide${r === 0 ? " active" : ""}`;
-    const g = document.createElement("img");
-    g.src = m.url, g.alt = m.alt || `Image ${r + 1}`, u.appendChild(g), t.appendChild(u);
+    const p = document.createElement("img");
+    p.src = g.url, p.alt = g.alt || `Image ${r + 1}`, u.appendChild(p), e.appendChild(u);
   }
-  const c = document.createElement("button");
-  c.className = "nav-button prev", c.innerHTML = `
+  const s = document.createElement("button");
+  s.className = "nav-button prev", s.innerHTML = `
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
     </svg>
   `;
-  const o = document.createElement("button");
-  o.className = "nav-button next", o.innerHTML = `
+  const a = document.createElement("button");
+  a.className = "nav-button next", a.innerHTML = `
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
     </svg>
   `;
-  let n = 0;
-  function p(r) {
-    const m = Array.from(
-      t.getElementsByClassName("slide")
+  let l = 0;
+  function c(r) {
+    const g = Array.from(
+      e.getElementsByClassName("slide")
     );
-    if (m[n].classList.remove("active"), m[r].classList.add("active"), i) {
+    if (g[l].classList.remove("active"), g[r].classList.add("active"), m) {
       const u = Array.from(
-        i.getElementsByTagName("img")
+        m.getElementsByTagName("img")
       );
-      u[n].classList.remove("active"), u[r].classList.add("active"), u[r].scrollIntoView({
+      u[l].classList.remove("active"), u[r].classList.add("active"), u[r].scrollIntoView({
         behavior: "smooth",
         block: "nearest",
         inline: "center"
       });
     }
-    n = r;
+    l = r;
   }
-  function s() {
-    const r = (n + 1) % l.length;
-    p(r);
+  function i() {
+    const r = (l + 1) % n.length;
+    c(r);
   }
   function d() {
-    const r = (n - 1 + l.length) % l.length;
-    p(r);
+    const r = (l - 1 + n.length) % n.length;
+    c(r);
   }
-  o.onclick = s, c.onclick = d, e.tabIndex = 0, e.onkeydown = (r) => {
-    r.key === "ArrowLeft" && d(), r.key === "ArrowRight" && s();
+  a.onclick = i, s.onclick = d, o.tabIndex = 0, o.onkeydown = (r) => {
+    r.key === "ArrowLeft" && d(), r.key === "ArrowRight" && i();
   };
-  let i;
-  if (a) {
-    i = document.createElement("div"), i.className = "thumbnails-container";
-    for (let r = 0; r < l.length; r++) {
-      const m = document.createElement("div");
-      m.className = "thumbnail-item";
+  let m;
+  if (t) {
+    m = document.createElement("div"), m.className = "thumbnails-container";
+    for (let r = 0; r < n.length; r++) {
+      const g = document.createElement("div");
+      g.className = "thumbnail-item";
       const u = document.createElement("img");
-      u.src = l[r].url, u.alt = l[r].alt || `Thumbnail ${r + 1}`, r === 0 && u.classList.add("active"), u.onclick = () => p(r), m.appendChild(u), i.appendChild(m);
+      u.src = n[r].url, u.alt = n[r].alt || `Thumbnail ${r + 1}`, r === 0 && u.classList.add("active"), u.onclick = () => c(r), g.appendChild(u), m.appendChild(g);
     }
   }
-  return e.appendChild(t), e.appendChild(c), e.appendChild(o), i && e.appendChild(i), e;
+  return o.appendChild(e), o.appendChild(s), o.appendChild(a), m && o.appendChild(m), o;
 }
-publish.registerMarkdownCodeBlockProcessor("image-layout", (l, a) => {
-  console.log("Processing image-layout block:", { source: l });
-  const { data: e, content: t } = f(l), c = y(t);
-  if (!e.layout) {
+publish.registerMarkdownCodeBlockProcessor("image-layout", (n, t) => {
+  console.log("Processing image-layout block:", { source: n });
+  const { data: o, content: e } = y(n), s = v(e);
+  if (!o.layout) {
     console.error("No layout specified in front matter");
     return;
   }
-  for (console.log("Parsed config:", { data: e, images: c }); a.firstChild; )
-    a.removeChild(a.firstChild);
-  const o = C(String(e.layout), c, e);
-  o && a.appendChild(o);
+  for (console.log("Parsed config:", { data: o, images: s }); t.firstChild; )
+    t.removeChild(t.firstChild);
+  const a = x(String(o.layout), s, o);
+  a && t.appendChild(a);
 });
-function C(l, a, e) {
-  const t = l.startsWith("legacy-layout-") ? l.slice(14) : l.startsWith("legacy-masonry-") ? `masonry-${l.slice(15)}` : l;
-  if (t === "carousel")
-    return E(a, e.showThumbnails !== !1);
-  if (t === "custom")
-    return x(a, String(e.grid ?? ""), e);
-  const c = t.match(/^masonry-([2-6])$/);
-  return c ? b(a, parseInt(c[1]), e) : h[t] ? v(a, t, e) : null;
+function x(n, t, o) {
+  const e = n.startsWith("legacy-layout-") ? n.slice(14) : n.startsWith("legacy-masonry-") ? `masonry-${n.slice(15)}` : n;
+  if (e === "carousel")
+    return T(t, o.showThumbnails !== !1);
+  if (e === "custom")
+    return A(t, String(o.grid ?? ""), o);
+  const s = e.match(/^masonry-([2-6])$/);
+  return s ? E(t, parseInt(s[1]), o) : f[e] ? b(t, e, o) : null;
 }
-function x(l, a, e) {
-  const t = a.split(`
-`).map((s) => s.trim()).filter((s) => s !== "").map((s) => s.split(/\s+/));
-  if (t.length === 0)
-    return null;
-  const c = t[0].length;
-  if (t.some((s) => s.length !== c))
-    return null;
-  const o = [];
-  for (const s of t)
-    for (const d of s)
-      d !== "." && !o.includes(d) && o.push(d);
-  if (o.length === 0)
-    return null;
-  const n = document.createElement("div");
-  if (n.className = "image-layouts image-layouts-grid", n.style.display = "grid", n.style.gap = "0.5rem", n.style.gridTemplateColumns = `repeat(${c}, 1fr)`, n.style.gridTemplateAreas = t.map(
-    (s) => `"${s.map((d) => d === "." ? "." : `image-${o.indexOf(d)}`).join(" ")}"`
-  ).join(" "), (l.length < o.length ? [
-    ...l,
-    ...Array(o.length - l.length).fill({
-      url: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='640' height='480'%3E%3Crect width='100%25' height='100%25' fill='%2388888822'/%3E%3C/svg%3E"
-    })
-  ] : l.slice(0, o.length)).forEach((s, d) => {
-    const i = document.createElement("div");
-    i.className = "group relative", i.style.gridArea = `image-${d}`;
-    const r = document.createElement("img");
-    r.src = s.url, r.alt = s.alt || `Image ${d + 1}`, r.className = "w-full h-full object-cover object-center", i.appendChild(r), n.appendChild(i);
-  }), e.caption) {
-    const s = document.createElement("div");
-    s.className = "text-center mt-2 text-sm text-gray-600", s.textContent = e.caption, n.appendChild(s);
+function h(n) {
+  const t = document.createElement("div");
+  return t.className = "image-layouts-error", t.style.cssText = "color: #888; font-size: 0.85em; padding: 0.5rem; border: 1px dashed #8886; border-radius: 6px; white-space: pre-wrap;", t.textContent = `Image Layouts: ${n}`, t;
+}
+function A(n, t, o) {
+  const e = t.split(`
+`).map((i) => i.trim()).filter((i) => i !== "").map((i) => i.split(/\s+/));
+  if (e.length === 0)
+    return h("A custom layout needs a `grid` option.");
+  const s = e[0].length;
+  if (e.some((i) => i.length !== s))
+    return h(
+      "Every row in `grid` must have the same number of cells."
+    );
+  const a = [];
+  for (const i of e)
+    for (const d of i)
+      d !== "." && !a.includes(d) && a.push(d);
+  if (a.length === 0)
+    return h("The `grid` needs at least one image cell.");
+  if (a.length > 20)
+    return h("`grid` supports up to 20 images.");
+  for (const i of a) {
+    let d = Number.POSITIVE_INFINITY, m = -1, r = Number.POSITIVE_INFINITY, g = -1, u = 0;
+    for (const [p, N] of e.entries())
+      for (const [I, L] of N.entries())
+        L === i && (d = Math.min(d, p), m = Math.max(m, p), r = Math.min(r, I), g = Math.max(g, I), u++);
+    if (u !== (m - d + 1) * (g - r + 1))
+      return h(
+        `The cells for "${i}" must form a solid rectangle.`
+      );
   }
-  return n;
+  const l = document.createElement("div");
+  return l.className = "image-layouts image-layouts-grid", l.style.display = "grid", l.style.gap = "0.5rem", l.style.gridTemplateColumns = `repeat(${s}, 1fr)`, l.style.gridTemplateAreas = e.map(
+    (i) => `"${i.map((d) => d === "." ? "." : `image-${a.indexOf(d)}`).join(" ")}"`
+  ).join(" "), k(n, a.length).forEach((i, d) => {
+    const m = w(i, d, o);
+    m.style.gridArea = `image-${d}`, l.appendChild(m);
+  }), C(l, o);
 }
-Object.keys(h).forEach((l) => {
+Object.keys(f).forEach((n) => {
   publish.registerMarkdownCodeBlockProcessor(
-    `image-layout-${l}`,
-    (a, e) => {
-      const { data: t, content: c } = f(a), o = y(c), n = v(o, l, t);
-      e.replaceChildren(n);
+    `image-layout-${n}`,
+    (t, o) => {
+      const { data: e, content: s } = y(t), a = v(s), l = b(a, n, e);
+      o.replaceChildren(l);
     }
   );
 });
-for (let l = 2; l <= 6; l++)
+for (let n = 2; n <= 6; n++)
   publish.registerMarkdownCodeBlockProcessor(
-    `image-layout-masonry-${l}`,
-    (a, e) => {
-      const { data: t, content: c } = f(a), o = y(c), n = b(o, l, t);
-      e.replaceChildren(n);
+    `image-layout-masonry-${n}`,
+    (t, o) => {
+      const { data: e, content: s } = y(t), a = v(s), l = E(a, n, e);
+      o.replaceChildren(l);
     }
   );
 console.log("Image Layouts loaded");
 document.addEventListener("DOMContentLoaded", () => {
   console.log("Processing existing image-layout blocks");
-  const l = document.querySelectorAll("pre > code.language-image-layout");
-  console.log("Found blocks:", l.length);
-  for (const a of l) {
-    const e = a.textContent || "", { data: t, content: c } = f(e), o = y(c);
-    if (console.log("Processing block:", { data: t, images: o }), o.length > 0) {
-      let n;
-      if (a.className.includes("language-image-layout-masonry-")) {
-        const p = parseInt(a.className.split("-").pop() || "2");
-        n = b(o, p, t);
-      } else if (a.className.includes("language-image-layout-")) {
-        const p = a.className.split("-").pop();
-        h[p] && (n = v(o, p, t));
+  const n = document.querySelectorAll("pre > code.language-image-layout");
+  console.log("Found blocks:", n.length);
+  for (const t of n) {
+    const o = t.textContent || "", { data: e, content: s } = y(o), a = v(s);
+    if (console.log("Processing block:", { data: e, images: a }), a.length > 0) {
+      let l;
+      if (t.className.includes("language-image-layout-masonry-")) {
+        const c = parseInt(t.className.split("-").pop() || "2");
+        l = E(a, c, e);
+      } else if (t.className.includes("language-image-layout-")) {
+        const c = t.className.split("-").pop();
+        f[c] && (l = b(a, c, e));
       } else
-        t.layout && (n = C(String(t.layout), o, t));
-      n && a.parentElement && (console.log("Replacing block with layout"), a.parentElement.replaceWith(n));
+        e.layout && (l = x(String(e.layout), a, e));
+      l && t.parentElement && (console.log("Replacing block with layout"), t.parentElement.replaceWith(l));
     }
   }
 });

--- a/test-vault/publish.js
+++ b/test-vault/publish.js
@@ -9,201 +9,248 @@ const h = {
   h: 3,
   i: 4,
   single: 1
-}, f = (n) => {
-  const o = n.split(`
+}, f = (l) => {
+  const a = l.split(`
 `), e = {
     data: {},
-    content: n
+    content: l
   };
-  if (o[0] !== "---")
+  if (a[0] !== "---")
     return e;
-  const t = o.slice(1).findIndex((l) => l === "---") + 1;
-  return t === 0 || (o.slice(1, t).join(`
+  const t = a.slice(1).findIndex((n) => n === "---") + 1;
+  if (t === 0)
+    return e;
+  const o = a.slice(1, t).join(`
 `).split(`
-`).forEach((l) => {
-    const [d, ...p] = l.split(":").map((u) => u.trim()), m = p.join(":").trim().replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1");
-    d && m && (m === "true" ? e.data[d] = !0 : m === "false" ? e.data[d] = !1 : e.data[d] = m);
-  }), e.content = o.slice(t + 1).join(`
-`)), e;
-}, k = (n) => {
-  const o = n.match(/\[([^\]]*)\]\(([^\(]*)\)/);
-  if (o) {
-    const [e, t, s] = o;
-    return { url: s, alt: t };
+`);
+  for (let n = 0; n < o.length; n++) {
+    const p = o[n], [s, ...d] = p.split(":").map((r) => r.trim()), i = d.join(":").trim().replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1");
+    if (s && (i === "|" || i === ">")) {
+      const r = [];
+      for (; n + 1 < o.length && (/^\s/.test(o[n + 1]) || o[n + 1] === ""); )
+        n++, r.push(o[n].trim());
+      e.data[s] = r.join(`
+`);
+      continue;
+    }
+    s && i && (i === "true" ? e.data[s] = !0 : i === "false" ? e.data[s] = !1 : e.data[s] = i);
+  }
+  return e.content = a.slice(t + 1).join(`
+`), e;
+}, w = (l) => {
+  const a = l.match(/\[([^\]]*)\]\(([^\(]*)\)/);
+  if (a) {
+    const [e, t, c] = a;
+    return { url: c, alt: t };
   }
   return null;
-}, y = (n) => n.split(`
-`).filter((t) => t.startsWith("!")).map((t) => k(t.slice(1))).filter((t) => t !== null);
+}, y = (l) => l.split(`
+`).filter((t) => t.startsWith("!")).map((t) => w(t.slice(1))).filter((t) => t !== null);
 console.log("Image Layouts loading...");
-function v(n, o, e) {
+function v(l, a, e) {
   const t = document.createElement("div");
-  t.className = `image-layouts image-layouts-grid image-layouts-layout-${o}`;
-  const s = h[o];
-  if ((n.length < s ? [
-    ...n,
-    ...Array(s - n.length).fill({
+  t.className = `image-layouts image-layouts-grid image-layouts-layout-${a}`;
+  const c = h[a];
+  if ((l.length < c ? [
+    ...l,
+    ...Array(c - l.length).fill({
       url: "https://via.placeholder.com/640x480"
     })
-  ] : n.slice(0, s)).forEach((l, d) => {
-    var u;
-    const p = document.createElement("div");
-    p.className = `group relative image-layouts-image-${d}`;
-    const m = document.createElement("img");
-    if (m.src = l.url, m.alt = l.alt || `Image ${d + 1}`, m.className = "w-full h-full object-cover object-center", l.alt || e.descriptions && e.descriptions[d]) {
-      const c = ((u = e.descriptions) == null ? void 0 : u[d]) || l.alt, r = document.createElement("div");
-      r.className = "absolute bottom-0 left-0 right-0 flex items-end p-4", r.setAttribute("aria-hidden", "true"), e.permanentOverlay || r.classList.add("opacity-0", "group-hover:opacity-100");
-      const i = document.createElement("div");
-      i.className = "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter", i.textContent = c, r.appendChild(i), p.appendChild(r);
+  ] : l.slice(0, c)).forEach((n, p) => {
+    var i;
+    const s = document.createElement("div");
+    s.className = `group relative image-layouts-image-${p}`;
+    const d = document.createElement("img");
+    if (d.src = n.url, d.alt = n.alt || `Image ${p + 1}`, d.className = "w-full h-full object-cover object-center", n.alt || e.descriptions && e.descriptions[p]) {
+      const r = ((i = e.descriptions) == null ? void 0 : i[p]) || n.alt, m = document.createElement("div");
+      m.className = "absolute bottom-0 left-0 right-0 flex items-end p-4", m.setAttribute("aria-hidden", "true"), e.permanentOverlay || m.classList.add("opacity-0", "group-hover:opacity-100");
+      const u = document.createElement("div");
+      u.className = "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter", u.textContent = r, m.appendChild(u), s.appendChild(m);
     }
-    p.appendChild(m), t.appendChild(p);
+    s.appendChild(d), t.appendChild(s);
   }), e.caption) {
-    const l = document.createElement("div");
-    l.className = "text-center mt-2 text-sm text-gray-600", l.textContent = e.caption, t.appendChild(l);
+    const n = document.createElement("div");
+    n.className = "text-center mt-2 text-sm text-gray-600", n.textContent = e.caption, t.appendChild(n);
   }
   return t;
 }
-function b(n, o, e) {
+function b(l, a, e) {
   const t = document.createElement("div");
-  t.className = `image-layouts-masonry-grid-${o}`;
-  const s = Array(o).fill(null).map(() => {
-    const a = document.createElement("div");
-    return a.className = "image-layouts-masonry-column", a;
+  t.className = `image-layouts-masonry-grid-${a}`;
+  const c = Array(a).fill(null).map(() => {
+    const o = document.createElement("div");
+    return o.className = "image-layouts-masonry-column", o;
   });
-  if (n.forEach((a, l) => {
-    var u;
-    const d = l % o, p = document.createElement("div");
-    p.className = "group relative";
-    const m = document.createElement("img");
-    if (m.src = a.url, m.alt = a.alt || `Image ${l + 1}`, m.className = "w-full h-full object-cover object-center", a.alt || e.descriptions && e.descriptions[l]) {
-      const c = ((u = e.descriptions) == null ? void 0 : u[l]) || a.alt, r = document.createElement("div");
-      r.className = "absolute bottom-0 left-0 right-0 flex items-end p-4", r.setAttribute("aria-hidden", "true"), e.permanentOverlay || r.classList.add("opacity-0", "group-hover:opacity-100");
-      const i = document.createElement("div");
-      i.className = "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter", i.textContent = c, r.appendChild(i), p.appendChild(r);
+  if (l.forEach((o, n) => {
+    var i;
+    const p = n % a, s = document.createElement("div");
+    s.className = "group relative";
+    const d = document.createElement("img");
+    if (d.src = o.url, d.alt = o.alt || `Image ${n + 1}`, d.className = "w-full h-full object-cover object-center", o.alt || e.descriptions && e.descriptions[n]) {
+      const r = ((i = e.descriptions) == null ? void 0 : i[n]) || o.alt, m = document.createElement("div");
+      m.className = "absolute bottom-0 left-0 right-0 flex items-end p-4", m.setAttribute("aria-hidden", "true"), e.permanentOverlay || m.classList.add("opacity-0", "group-hover:opacity-100");
+      const u = document.createElement("div");
+      u.className = "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter", u.textContent = r, m.appendChild(u), s.appendChild(m);
     }
-    p.appendChild(m), s[d].appendChild(p);
-  }), s.forEach((a) => t.appendChild(a)), e.caption) {
-    const a = document.createElement("div");
-    a.className = "text-center mt-2 text-sm text-gray-600", a.textContent = e.caption, t.appendChild(a);
+    s.appendChild(d), c[p].appendChild(s);
+  }), c.forEach((o) => t.appendChild(o)), e.caption) {
+    const o = document.createElement("div");
+    o.className = "text-center mt-2 text-sm text-gray-600", o.textContent = e.caption, t.appendChild(o);
   }
   return t;
 }
-function w(n, o) {
+function E(l, a) {
   const e = document.createElement("div");
   e.className = "image-layout-carousel";
   const t = document.createElement("div");
   t.className = "slides-container";
-  for (const [c, r] of n.entries()) {
-    const i = document.createElement("div");
-    i.className = `slide${c === 0 ? " active" : ""}`;
+  for (const [r, m] of l.entries()) {
+    const u = document.createElement("div");
+    u.className = `slide${r === 0 ? " active" : ""}`;
     const g = document.createElement("img");
-    g.src = r.url, g.alt = r.alt || `Image ${c + 1}`, i.appendChild(g), t.appendChild(i);
+    g.src = m.url, g.alt = m.alt || `Image ${r + 1}`, u.appendChild(g), t.appendChild(u);
   }
-  const s = document.createElement("button");
-  s.className = "nav-button prev", s.innerHTML = `
+  const c = document.createElement("button");
+  c.className = "nav-button prev", c.innerHTML = `
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
     </svg>
   `;
-  const a = document.createElement("button");
-  a.className = "nav-button next", a.innerHTML = `
+  const o = document.createElement("button");
+  o.className = "nav-button next", o.innerHTML = `
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
     </svg>
   `;
-  let l = 0;
-  function d(c) {
-    const r = Array.from(
+  let n = 0;
+  function p(r) {
+    const m = Array.from(
       t.getElementsByClassName("slide")
     );
-    if (r[l].classList.remove("active"), r[c].classList.add("active"), u) {
-      const i = Array.from(
-        u.getElementsByTagName("img")
+    if (m[n].classList.remove("active"), m[r].classList.add("active"), i) {
+      const u = Array.from(
+        i.getElementsByTagName("img")
       );
-      i[l].classList.remove("active"), i[c].classList.add("active"), i[c].scrollIntoView({
+      u[n].classList.remove("active"), u[r].classList.add("active"), u[r].scrollIntoView({
         behavior: "smooth",
         block: "nearest",
         inline: "center"
       });
     }
-    l = c;
+    n = r;
   }
-  function p() {
-    const c = (l + 1) % n.length;
-    d(c);
+  function s() {
+    const r = (n + 1) % l.length;
+    p(r);
   }
-  function m() {
-    const c = (l - 1 + n.length) % n.length;
-    d(c);
+  function d() {
+    const r = (n - 1 + l.length) % l.length;
+    p(r);
   }
-  a.onclick = p, s.onclick = m, e.tabIndex = 0, e.onkeydown = (c) => {
-    c.key === "ArrowLeft" && m(), c.key === "ArrowRight" && p();
+  o.onclick = s, c.onclick = d, e.tabIndex = 0, e.onkeydown = (r) => {
+    r.key === "ArrowLeft" && d(), r.key === "ArrowRight" && s();
   };
-  let u;
-  if (o) {
-    u = document.createElement("div"), u.className = "thumbnails-container";
-    for (let c = 0; c < n.length; c++) {
-      const r = document.createElement("div");
-      r.className = "thumbnail-item";
-      const i = document.createElement("img");
-      i.src = n[c].url, i.alt = n[c].alt || `Thumbnail ${c + 1}`, c === 0 && i.classList.add("active"), i.onclick = () => d(c), r.appendChild(i), u.appendChild(r);
+  let i;
+  if (a) {
+    i = document.createElement("div"), i.className = "thumbnails-container";
+    for (let r = 0; r < l.length; r++) {
+      const m = document.createElement("div");
+      m.className = "thumbnail-item";
+      const u = document.createElement("img");
+      u.src = l[r].url, u.alt = l[r].alt || `Thumbnail ${r + 1}`, r === 0 && u.classList.add("active"), u.onclick = () => p(r), m.appendChild(u), i.appendChild(m);
     }
   }
-  return e.appendChild(t), e.appendChild(s), e.appendChild(a), u && e.appendChild(u), e;
+  return e.appendChild(t), e.appendChild(c), e.appendChild(o), i && e.appendChild(i), e;
 }
-publish.registerMarkdownCodeBlockProcessor("image-layout", (n, o) => {
-  console.log("Processing image-layout block:", { source: n });
-  const { data: e, content: t } = f(n), s = y(t);
+publish.registerMarkdownCodeBlockProcessor("image-layout", (l, a) => {
+  console.log("Processing image-layout block:", { source: l });
+  const { data: e, content: t } = f(l), c = y(t);
   if (!e.layout) {
     console.error("No layout specified in front matter");
     return;
   }
-  for (console.log("Parsed config:", { data: e, images: s }); o.firstChild; )
-    o.removeChild(o.firstChild);
-  const a = C(String(e.layout), s, e);
-  a && o.appendChild(a);
+  for (console.log("Parsed config:", { data: e, images: c }); a.firstChild; )
+    a.removeChild(a.firstChild);
+  const o = C(String(e.layout), c, e);
+  o && a.appendChild(o);
 });
-function C(n, o, e) {
-  const t = n.startsWith("legacy-layout-") ? n.slice(14) : n.startsWith("legacy-masonry-") ? `masonry-${n.slice(15)}` : n;
+function C(l, a, e) {
+  const t = l.startsWith("legacy-layout-") ? l.slice(14) : l.startsWith("legacy-masonry-") ? `masonry-${l.slice(15)}` : l;
   if (t === "carousel")
-    return w(o, e.showThumbnails !== !1);
-  const s = t.match(/^masonry-([2-6])$/);
-  return s ? b(o, parseInt(s[1]), e) : h[t] ? v(o, t, e) : null;
+    return E(a, e.showThumbnails !== !1);
+  if (t === "custom")
+    return x(a, String(e.grid ?? ""), e);
+  const c = t.match(/^masonry-([2-6])$/);
+  return c ? b(a, parseInt(c[1]), e) : h[t] ? v(a, t, e) : null;
 }
-Object.keys(h).forEach((n) => {
+function x(l, a, e) {
+  const t = a.split(`
+`).map((s) => s.trim()).filter((s) => s !== "").map((s) => s.split(/\s+/));
+  if (t.length === 0)
+    return null;
+  const c = t[0].length;
+  if (t.some((s) => s.length !== c))
+    return null;
+  const o = [];
+  for (const s of t)
+    for (const d of s)
+      d !== "." && !o.includes(d) && o.push(d);
+  if (o.length === 0)
+    return null;
+  const n = document.createElement("div");
+  if (n.className = "image-layouts image-layouts-grid", n.style.display = "grid", n.style.gap = "0.5rem", n.style.gridTemplateColumns = `repeat(${c}, 1fr)`, n.style.gridTemplateAreas = t.map(
+    (s) => `"${s.map((d) => d === "." ? "." : `image-${o.indexOf(d)}`).join(" ")}"`
+  ).join(" "), (l.length < o.length ? [
+    ...l,
+    ...Array(o.length - l.length).fill({
+      url: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='640' height='480'%3E%3Crect width='100%25' height='100%25' fill='%2388888822'/%3E%3C/svg%3E"
+    })
+  ] : l.slice(0, o.length)).forEach((s, d) => {
+    const i = document.createElement("div");
+    i.className = "group relative", i.style.gridArea = `image-${d}`;
+    const r = document.createElement("img");
+    r.src = s.url, r.alt = s.alt || `Image ${d + 1}`, r.className = "w-full h-full object-cover object-center", i.appendChild(r), n.appendChild(i);
+  }), e.caption) {
+    const s = document.createElement("div");
+    s.className = "text-center mt-2 text-sm text-gray-600", s.textContent = e.caption, n.appendChild(s);
+  }
+  return n;
+}
+Object.keys(h).forEach((l) => {
   publish.registerMarkdownCodeBlockProcessor(
-    `image-layout-${n}`,
-    (o, e) => {
-      const { data: t, content: s } = f(o), a = y(s), l = v(a, n, t);
-      e.replaceChildren(l);
+    `image-layout-${l}`,
+    (a, e) => {
+      const { data: t, content: c } = f(a), o = y(c), n = v(o, l, t);
+      e.replaceChildren(n);
     }
   );
 });
-for (let n = 2; n <= 6; n++)
+for (let l = 2; l <= 6; l++)
   publish.registerMarkdownCodeBlockProcessor(
-    `image-layout-masonry-${n}`,
-    (o, e) => {
-      const { data: t, content: s } = f(o), a = y(s), l = b(a, n, t);
-      e.replaceChildren(l);
+    `image-layout-masonry-${l}`,
+    (a, e) => {
+      const { data: t, content: c } = f(a), o = y(c), n = b(o, l, t);
+      e.replaceChildren(n);
     }
   );
 console.log("Image Layouts loaded");
 document.addEventListener("DOMContentLoaded", () => {
   console.log("Processing existing image-layout blocks");
-  const n = document.querySelectorAll("pre > code.language-image-layout");
-  console.log("Found blocks:", n.length);
-  for (const o of n) {
-    const e = o.textContent || "", { data: t, content: s } = f(e), a = y(s);
-    if (console.log("Processing block:", { data: t, images: a }), a.length > 0) {
-      let l;
-      if (o.className.includes("language-image-layout-masonry-")) {
-        const d = parseInt(o.className.split("-").pop() || "2");
-        l = b(a, d, t);
-      } else if (o.className.includes("language-image-layout-")) {
-        const d = o.className.split("-").pop();
-        h[d] && (l = v(a, d, t));
+  const l = document.querySelectorAll("pre > code.language-image-layout");
+  console.log("Found blocks:", l.length);
+  for (const a of l) {
+    const e = a.textContent || "", { data: t, content: c } = f(e), o = y(c);
+    if (console.log("Processing block:", { data: t, images: o }), o.length > 0) {
+      let n;
+      if (a.className.includes("language-image-layout-masonry-")) {
+        const p = parseInt(a.className.split("-").pop() || "2");
+        n = b(o, p, t);
+      } else if (a.className.includes("language-image-layout-")) {
+        const p = a.className.split("-").pop();
+        h[p] && (n = v(o, p, t));
       } else
-        t.layout && (l = C(String(t.layout), a, t));
-      l && o.parentElement && (console.log("Replacing block with layout"), o.parentElement.replaceWith(l));
+        t.layout && (n = C(String(t.layout), o, t));
+      n && a.parentElement && (console.log("Replacing block with layout"), a.parentElement.replaceWith(n));
     }
   }
 });

--- a/test-vault/publish.ts
+++ b/test-vault/publish.ts
@@ -1,3 +1,5 @@
+import { PLACEHOLDER_DATA_URI } from "../src/utils/placeholder";
+
 // Types
 type ImageLink = {
   url: string;
@@ -76,8 +78,9 @@ const parseFrontMatter = (
       .replace(/^"(.*)"$/, "$1")
       .replace(/^'(.*)'$/, "$1");
 
-    // Block scalars (`grid: |`): consume the following indented lines.
-    if (key && (value === "|" || value === ">")) {
+    // Block scalars (`grid: |`, including chomping/indent indicators like
+    // `|-` or `>2`): consume the following indented lines.
+    if (key && /^[|>][+-]?\d*$/.test(value)) {
       const blockLines: string[] = [];
       while (
         i + 1 < frontMatterLines.length &&
@@ -123,6 +126,67 @@ const getImages = (source: string): ImageLink[] => {
 
 console.log("Image Layouts loading...");
 
+function padImages(images: ImageLink[], slots: number): ImageLink[] {
+  return images.length < slots
+    ? [
+        ...images,
+        ...Array(slots - images.length).fill({ url: PLACEHOLDER_DATA_URI }),
+      ]
+    : images.slice(0, slots);
+}
+
+// Shared image cell (wrapper + img + optional description overlay). One
+// builder keeps the grid, masonry, and custom renderers from drifting apart.
+function createImageCell(
+  image: ImageLink,
+  index: number,
+  config: FrontMatter
+): HTMLElement {
+  const wrapper = document.createElement("div");
+  wrapper.className = "group relative";
+
+  const img = document.createElement("img");
+  img.src = image.url;
+  img.alt = image.alt || `Image ${index + 1}`;
+  img.className = "w-full h-full object-cover object-center";
+
+  const description = config.descriptions?.[index] || image.alt;
+  if (description) {
+    const overlay = document.createElement("div");
+    overlay.className = "absolute bottom-0 left-0 right-0 flex items-end p-4";
+    overlay.setAttribute("aria-hidden", "true");
+    if (!config.permanentOverlay) {
+      overlay.classList.add("opacity-0", "group-hover:opacity-100");
+    }
+
+    const text = document.createElement("div");
+    text.className =
+      "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter";
+    text.textContent = description;
+
+    overlay.appendChild(text);
+    wrapper.appendChild(overlay);
+  }
+
+  wrapper.appendChild(img);
+  return wrapper;
+}
+
+// Caption below the layout, outside the grid container so it can't be
+// auto-placed into an empty grid cell.
+function withCaption(layout: HTMLElement, config: FrontMatter): HTMLElement {
+  if (!config.caption) {
+    return layout;
+  }
+  const outer = document.createElement("div");
+  outer.appendChild(layout);
+  const caption = document.createElement("div");
+  caption.className = "text-center mt-2 text-sm text-gray-600";
+  caption.textContent = config.caption;
+  outer.appendChild(caption);
+  return outer;
+}
+
 // Create legacy grid layout
 function createLegacyGridLayout(
   images: ImageLink[],
@@ -132,56 +196,14 @@ function createLegacyGridLayout(
   const container = document.createElement("div");
   container.className = `image-layouts image-layouts-grid image-layouts-layout-${layout}`;
 
-  const requiredImages = layoutImages[layout];
-  const displayImages =
-    images.length < requiredImages
-      ? [
-          ...images,
-          ...Array(requiredImages - images.length).fill({
-            url: "https://via.placeholder.com/640x480",
-          }),
-        ]
-      : images.slice(0, requiredImages);
-
+  const displayImages = padImages(images, layoutImages[layout]);
   displayImages.forEach((image, index) => {
-    const wrapper = document.createElement("div");
-    wrapper.className = `group relative image-layouts-image-${index}`;
-
-    const img = document.createElement("img");
-    img.src = image.url;
-    img.alt = image.alt || `Image ${index + 1}`;
-    img.className = "w-full h-full object-cover object-center";
-
-    if (image.alt || (config.descriptions && config.descriptions[index])) {
-      const description = config.descriptions?.[index] || image.alt;
-      const overlay = document.createElement("div");
-      overlay.className = "absolute bottom-0 left-0 right-0 flex items-end p-4";
-      overlay.setAttribute("aria-hidden", "true");
-      if (!config.permanentOverlay) {
-        overlay.classList.add("opacity-0", "group-hover:opacity-100");
-      }
-
-      const text = document.createElement("div");
-      text.className =
-        "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter";
-      text.textContent = description;
-
-      overlay.appendChild(text);
-      wrapper.appendChild(overlay);
-    }
-
-    wrapper.appendChild(img);
-    container.appendChild(wrapper);
+    const cell = createImageCell(image, index, config);
+    cell.classList.add(`image-layouts-image-${index}`);
+    container.appendChild(cell);
   });
 
-  if (config.caption) {
-    const caption = document.createElement("div");
-    caption.className = "text-center mt-2 text-sm text-gray-600";
-    caption.textContent = config.caption;
-    container.appendChild(caption);
-  }
-
-  return container;
+  return withCaption(container, config);
 }
 
 // Create masonry layout
@@ -205,47 +227,15 @@ function createMasonryLayout(
   // Distribute images across columns
   images.forEach((image, index) => {
     const colIndex = index % columns;
-    const wrapper = document.createElement("div");
-    wrapper.className = "group relative";
-
-    const img = document.createElement("img");
-    img.src = image.url;
-    img.alt = image.alt || `Image ${index + 1}`;
-    img.className = "w-full h-full object-cover object-center";
-
-    if (image.alt || (config.descriptions && config.descriptions[index])) {
-      const description = config.descriptions?.[index] || image.alt;
-      const overlay = document.createElement("div");
-      overlay.className = "absolute bottom-0 left-0 right-0 flex items-end p-4";
-      overlay.setAttribute("aria-hidden", "true");
-      if (!config.permanentOverlay) {
-        overlay.classList.add("opacity-0", "group-hover:opacity-100");
-      }
-
-      const text = document.createElement("div");
-      text.className =
-        "w-full rounded-md bg-white bg-opacity-75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur backdrop-filter";
-      text.textContent = description;
-
-      overlay.appendChild(text);
-      wrapper.appendChild(overlay);
-    }
-
-    wrapper.appendChild(img);
-    columnElements[colIndex].appendChild(wrapper);
+    columnElements[colIndex].appendChild(
+      createImageCell(image, index, config)
+    );
   });
 
   // Add columns to container
   columnElements.forEach((col) => container.appendChild(col));
 
-  if (config.caption) {
-    const caption = document.createElement("div");
-    caption.className = "text-center mt-2 text-sm text-gray-600";
-    caption.textContent = config.caption;
-    container.appendChild(caption);
-  }
-
-  return container;
+  return withCaption(container, config);
 }
 
 // Create carousel
@@ -438,19 +428,34 @@ function createModernLayout(
 // Renders `layout: custom` blocks: rows of whitespace-separated tokens map
 // to CSS grid-template-areas; "." leaves a cell empty. Mirrors
 // src/utils/custom-grid.ts in the plugin.
+function createCustomGridError(message: string): HTMLElement {
+  const errorEl = document.createElement("div");
+  errorEl.className = "image-layouts-error";
+  errorEl.style.cssText =
+    "color: #888; font-size: 0.85em; padding: 0.5rem; border: 1px dashed #8886; border-radius: 6px; white-space: pre-wrap;";
+  errorEl.textContent = `Image Layouts: ${message}`;
+  return errorEl;
+}
+
 function createCustomGridLayout(
   images: ImageLink[],
   gridSpec: string,
   config: FrontMatter
-): HTMLElement | null {
+): HTMLElement {
   const rows = gridSpec
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line !== "")
     .map((line) => line.split(/\s+/));
-  if (rows.length === 0) return null;
+  if (rows.length === 0) {
+    return createCustomGridError("A custom layout needs a `grid` option.");
+  }
   const columns = rows[0].length;
-  if (rows.some((row) => row.length !== columns)) return null;
+  if (rows.some((row) => row.length !== columns)) {
+    return createCustomGridError(
+      "Every row in `grid` must have the same number of cells."
+    );
+  }
 
   const order: string[] = [];
   for (const row of rows) {
@@ -458,7 +463,39 @@ function createCustomGridLayout(
       if (cell !== "." && !order.includes(cell)) order.push(cell);
     }
   }
-  if (order.length === 0) return null;
+  if (order.length === 0) {
+    return createCustomGridError("The `grid` needs at least one image cell.");
+  }
+  if (order.length > 20) {
+    return createCustomGridError("`grid` supports up to 20 images.");
+  }
+
+  // grid-template-areas requires solid rectangles; an invalid template
+  // would be discarded by the browser and stack every image on top of
+  // each other, so validate here like the in-app renderer does.
+  for (const token of order) {
+    let minRow = Number.POSITIVE_INFINITY;
+    let maxRow = -1;
+    let minCol = Number.POSITIVE_INFINITY;
+    let maxCol = -1;
+    let count = 0;
+    for (const [r, row] of rows.entries()) {
+      for (const [c, cell] of row.entries()) {
+        if (cell === token) {
+          minRow = Math.min(minRow, r);
+          maxRow = Math.max(maxRow, r);
+          minCol = Math.min(minCol, c);
+          maxCol = Math.max(maxCol, c);
+          count++;
+        }
+      }
+    }
+    if (count !== (maxRow - minRow + 1) * (maxCol - minCol + 1)) {
+      return createCustomGridError(
+        `The cells for "${token}" must form a solid rectangle.`
+      );
+    }
+  }
 
   const container = document.createElement("div");
   container.className = "image-layouts image-layouts-grid";
@@ -474,37 +511,14 @@ function createCustomGridLayout(
     )
     .join(" ");
 
-  const displayImages =
-    images.length < order.length
-      ? [
-          ...images,
-          ...Array(order.length - images.length).fill({
-            url: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='640' height='480'%3E%3Crect width='100%25' height='100%25' fill='%2388888822'/%3E%3C/svg%3E",
-          }),
-        ]
-      : images.slice(0, order.length);
-
+  const displayImages = padImages(images, order.length);
   displayImages.forEach((image, index) => {
-    const wrapper = document.createElement("div");
-    wrapper.className = "group relative";
-    wrapper.style.gridArea = `image-${index}`;
-
-    const img = document.createElement("img");
-    img.src = image.url;
-    img.alt = image.alt || `Image ${index + 1}`;
-    img.className = "w-full h-full object-cover object-center";
-    wrapper.appendChild(img);
-    container.appendChild(wrapper);
+    const cell = createImageCell(image, index, config);
+    cell.style.gridArea = `image-${index}`;
+    container.appendChild(cell);
   });
 
-  if (config.caption) {
-    const caption = document.createElement("div");
-    caption.className = "text-center mt-2 text-sm text-gray-600";
-    caption.textContent = config.caption;
-    container.appendChild(caption);
-  }
-
-  return container;
+  return withCaption(container, config);
 }
 
 // Register legacy layout processors for backward compatibility

--- a/test-vault/publish.ts
+++ b/test-vault/publish.ts
@@ -19,6 +19,7 @@ type LayoutType =
 type FrontMatter = {
   type?: string;
   layout?: string;
+  grid?: string;
   showThumbnails?: boolean;
   caption?: string;
   descriptions?: string[];
@@ -64,7 +65,8 @@ const parseFrontMatter = (
   const frontMatter = lines.slice(1, endIndex).join("\n");
   const frontMatterLines = frontMatter.split("\n");
 
-  frontMatterLines.forEach((line) => {
+  for (let i = 0; i < frontMatterLines.length; i++) {
+    const line = frontMatterLines[i];
     const [key, ...valueParts] = line.split(":").map((part) => part.trim());
     // Strip surrounding quotes so YAML like `layout: "carousel"` (as the
     // in-app layout picker writes) parses the same as `layout: carousel`.
@@ -74,12 +76,26 @@ const parseFrontMatter = (
       .replace(/^"(.*)"$/, "$1")
       .replace(/^'(.*)'$/, "$1");
 
+    // Block scalars (`grid: |`): consume the following indented lines.
+    if (key && (value === "|" || value === ">")) {
+      const blockLines: string[] = [];
+      while (
+        i + 1 < frontMatterLines.length &&
+        (/^\s/.test(frontMatterLines[i + 1]) || frontMatterLines[i + 1] === "")
+      ) {
+        i++;
+        blockLines.push(frontMatterLines[i].trim());
+      }
+      result.data[key] = blockLines.join("\n");
+      continue;
+    }
+
     if (key && value) {
       if (value === "true") result.data[key] = true;
       else if (value === "false") result.data[key] = false;
       else result.data[key] = value;
     }
-  });
+  }
 
   // Extract the content after front matter
   result.content = lines.slice(endIndex + 1).join("\n");
@@ -406,6 +422,9 @@ function createModernLayout(
   if (normalized === "carousel") {
     return createCarousel(images, data.showThumbnails !== false); // Default to showing thumbnails
   }
+  if (normalized === "custom") {
+    return createCustomGridLayout(images, String(data.grid ?? ""), data);
+  }
   const masonry = normalized.match(/^masonry-([2-6])$/);
   if (masonry) {
     return createMasonryLayout(images, parseInt(masonry[1]), data);
@@ -414,6 +433,78 @@ function createModernLayout(
     return createLegacyGridLayout(images, normalized as LayoutType, data);
   }
   return null;
+}
+
+// Renders `layout: custom` blocks: rows of whitespace-separated tokens map
+// to CSS grid-template-areas; "." leaves a cell empty. Mirrors
+// src/utils/custom-grid.ts in the plugin.
+function createCustomGridLayout(
+  images: ImageLink[],
+  gridSpec: string,
+  config: FrontMatter
+): HTMLElement | null {
+  const rows = gridSpec
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "")
+    .map((line) => line.split(/\s+/));
+  if (rows.length === 0) return null;
+  const columns = rows[0].length;
+  if (rows.some((row) => row.length !== columns)) return null;
+
+  const order: string[] = [];
+  for (const row of rows) {
+    for (const cell of row) {
+      if (cell !== "." && !order.includes(cell)) order.push(cell);
+    }
+  }
+  if (order.length === 0) return null;
+
+  const container = document.createElement("div");
+  container.className = "image-layouts image-layouts-grid";
+  container.style.display = "grid";
+  container.style.gap = "0.5rem";
+  container.style.gridTemplateColumns = `repeat(${columns}, 1fr)`;
+  container.style.gridTemplateAreas = rows
+    .map(
+      (row) =>
+        `"${row
+          .map((cell) => (cell === "." ? "." : `image-${order.indexOf(cell)}`))
+          .join(" ")}"`
+    )
+    .join(" ");
+
+  const displayImages =
+    images.length < order.length
+      ? [
+          ...images,
+          ...Array(order.length - images.length).fill({
+            url: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='640' height='480'%3E%3Crect width='100%25' height='100%25' fill='%2388888822'/%3E%3C/svg%3E",
+          }),
+        ]
+      : images.slice(0, order.length);
+
+  displayImages.forEach((image, index) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "group relative";
+    wrapper.style.gridArea = `image-${index}`;
+
+    const img = document.createElement("img");
+    img.src = image.url;
+    img.alt = image.alt || `Image ${index + 1}`;
+    img.className = "w-full h-full object-cover object-center";
+    wrapper.appendChild(img);
+    container.appendChild(wrapper);
+  });
+
+  if (config.caption) {
+    const caption = document.createElement("div");
+    caption.className = "text-center mt-2 text-sm text-gray-600";
+    caption.textContent = config.caption;
+    container.appendChild(caption);
+  }
+
+  return container;
 }
 
 // Register legacy layout processors for backward compatibility

--- a/test/blocks.test.ts
+++ b/test/blocks.test.ts
@@ -119,3 +119,19 @@ test("buildLayoutBlock lengthens its fence past backtick runs in the content", (
   expect(block.startsWith("````image-layout\n")).toBe(true);
   expect(block.endsWith("\n````\n")).toBe(true);
 });
+
+test("updateLayoutInBlockSource seeds a starter grid when picking custom", () => {
+  expect(updateLayoutInBlockSource("![[a.jpg]]\n", { type: "custom" })).toBe(
+    "---\nlayout: custom\ngrid: |\n  A A B\n  A A C\n---\n![[a.jpg]]\n",
+  );
+  expect(
+    updateLayoutInBlockSource("---\ncaption: Hi\n---\n", { type: "custom" }),
+  ).toBe("---\ncaption: Hi\nlayout: custom\ngrid: |\n  A A B\n  A A C\n---\n");
+});
+
+test("updateLayoutInBlockSource keeps an existing grid when picking custom", () => {
+  const source = "---\nlayout: a\ngrid: |\n  X X\n  Y Z\n---\n![[a.jpg]]\n";
+  expect(updateLayoutInBlockSource(source, { type: "custom" })).toBe(
+    "---\nlayout: custom\ngrid: |\n  X X\n  Y Z\n---\n![[a.jpg]]\n",
+  );
+});

--- a/test/blocks.test.ts
+++ b/test/blocks.test.ts
@@ -135,3 +135,13 @@ test("updateLayoutInBlockSource keeps an existing grid when picking custom", () 
     "---\nlayout: custom\ngrid: |\n  X X\n  Y Z\n---\n![[a.jpg]]\n",
   );
 });
+
+test("updateLayoutInBlockSource ignores keys inside block scalars", () => {
+  // "grid:" and "layout:" appear indented inside the caption block scalar —
+  // they are content, not keys, and must not suppress seeding or be edited.
+  const source =
+    "---\ncaption: |\n  grid: sketch\n  layout: moodboard\n---\n![[a.jpg]]\n";
+  expect(updateLayoutInBlockSource(source, { type: "custom" })).toBe(
+    "---\ncaption: |\n  grid: sketch\n  layout: moodboard\nlayout: custom\ngrid: |\n  A A B\n  A A C\n---\n![[a.jpg]]\n",
+  );
+});

--- a/test/custom-grid.test.ts
+++ b/test/custom-grid.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "vitest";
+import { parseCustomGrid } from "../src/utils/custom-grid.ts";
+
+test("parseCustomGrid maps tokens in order of first appearance", () => {
+  const result = parseCustomGrid("A A B\nA A C\n");
+  expect(result.error).toBeUndefined();
+  expect(result.grid).toEqual({
+    columns: 3,
+    rows: 2,
+    slots: 3,
+    templateAreas: '"image-0 image-0 image-1" "image-0 image-0 image-2"',
+  });
+});
+
+test("parseCustomGrid supports empty cells with dots", () => {
+  const result = parseCustomGrid("A . B\nA . B");
+  expect(result.grid?.templateAreas).toBe(
+    '"image-0 . image-1" "image-0 . image-1"',
+  );
+  expect(result.grid?.slots).toBe(2);
+});
+
+test("parseCustomGrid accepts a single row", () => {
+  const result = parseCustomGrid("A B C D");
+  expect(result.grid?.columns).toBe(4);
+  expect(result.grid?.slots).toBe(4);
+});
+
+test("parseCustomGrid rejects ragged rows", () => {
+  const result = parseCustomGrid("A A\nA");
+  expect(result.error).toMatch(/same number of cells/);
+});
+
+test("parseCustomGrid rejects non-rectangular regions", () => {
+  // A forms an L shape
+  const result = parseCustomGrid("A A\nA B");
+  expect(result.error).toMatch(/solid rectangle/);
+});
+
+test("parseCustomGrid rejects disjoint regions of the same token", () => {
+  const result = parseCustomGrid("A B A");
+  expect(result.error).toMatch(/solid rectangle/);
+});
+
+test("parseCustomGrid rejects missing or empty grids", () => {
+  expect(parseCustomGrid(undefined).error).toBeDefined();
+  expect(parseCustomGrid(null).error).toBeDefined();
+  expect(parseCustomGrid("").error).toBeDefined();
+  expect(parseCustomGrid(". .\n. .").error).toMatch(/at least one/);
+});
+
+test("parseCustomGrid handles multi-character tokens", () => {
+  const result = parseCustomGrid("hero hero side\nhero hero foot");
+  expect(result.grid?.slots).toBe(3);
+  expect(result.grid?.templateAreas).toBe(
+    '"image-0 image-0 image-1" "image-0 image-0 image-2"',
+  );
+});


### PR DESCRIPTION
## Summary

Closes the last open issue on the tracker.

`layout: custom` + an ASCII-art `grid`:

~~~
```image-layout
---
layout: custom
grid: |
  A A B
  A A C
---
![[hero.jpg]]
![[detail-1.jpg]]
![[detail-2.jpg]]
```
~~~

- Equal letters merge into one region; `.` leaves a cell empty; letters map to images in order of first appearance (multi-char tokens like `hero` work too).
- Validation with readable errors for ragged rows and non-rectangular regions — CSS would silently discard the whole template otherwise.
- The picker gets a "custom" tile (modern blocks only) that seeds a starter grid when none exists; switching to custom never touches an existing `grid`.
- publish.js learns YAML block scalars (`grid: |`) and renders custom grids, keeping published sites in parity.
- 52 unit tests (10 new: parser edge cases + starter-grid insertion).

Closes #15

https://claude.ai/code/session_01C3XcBQRGY2q7CmFSvYM4WY